### PR TITLE
feat(upload): strip image metadata before upload on web, Electron, and Android

### DIFF
--- a/android/app/src/main/java/fivechan/android/FileUploaderPlugin.java
+++ b/android/app/src/main/java/fivechan/android/FileUploaderPlugin.java
@@ -2,7 +2,9 @@ package fivechan.android;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.database.Cursor;
 import android.net.Uri;
+import android.provider.OpenableColumns;
 import android.util.Base64;
 import android.util.Log;
 
@@ -98,7 +100,9 @@ public class FileUploaderPlugin extends Plugin {
                             try {
                                 cachedFile = FileUtils.writeBytesToCacheFile(getContext(), fileName, bytes);
                                 tryProvidersSequentially(Uri.fromFile(cachedFile), providerOrder, call, fileName, bytes, mimeType);
-                            } catch (Exception e) {
+                            } catch (Throwable e) {
+                                // Throwable, not Exception: an OutOfMemoryError must still
+                                // settle the call or the web layer awaits it forever.
                                 Log.e(TAG, "Generated upload failed", e);
                                 try {
                                     call.reject("Upload failed: " + e.getMessage());
@@ -200,7 +204,9 @@ public class FileUploaderPlugin extends Plugin {
                                         stripped.fileName,
                                         stripped.bytes,
                                         stripped.mimeType);
-                            } catch (Exception e) {
+                            } catch (Throwable e) {
+                                // Throwable, not Exception: an OutOfMemoryError must still
+                                // settle the call or the web layer awaits it forever.
                                 Log.e(TAG, "Upload failed", e);
                                 try {
                                     call.reject("Upload failed: " + e.getMessage());
@@ -251,7 +257,9 @@ public class FileUploaderPlugin extends Plugin {
                 mimeType = MediaMetadataStripper.sniffMimeType(strippedBytes);
             }
             return new StrippedPickedMedia(strippedBytes, getFileName(uri), mimeType);
-        } catch (Exception e) {
+        } catch (Throwable e) {
+            // Throwable, not Exception: stripping a near-cap image can throw
+            // OutOfMemoryError, which must fall back to the original upload.
             Log.w(TAG, "Metadata strip failed, uploading picked file unchanged", e);
             return null;
         }
@@ -263,6 +271,10 @@ public class FileUploaderPlugin extends Plugin {
      * never loaded into memory.
      */
     private byte[] readStrippableBytes(Uri uri) throws Exception {
+        long sizeHint = queryContentSize(uri);
+        if (sizeHint > MediaMetadataStripper.MAX_PROCESSABLE_BYTES) {
+            return null; // over the size cap: pass through without reading
+        }
         try (InputStream input = getContext().getContentResolver().openInputStream(uri)) {
             if (input == null) {
                 return null;
@@ -279,7 +291,10 @@ public class FileUploaderPlugin extends Plugin {
             if (!MediaMetadataStripper.isStrippableFormat(header, headerLength)) {
                 return null;
             }
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            // Pre-size with the reported size to avoid the transient 2x cost of
+            // growth-doubling; a wrong hint self-corrects (the stream grows) and
+            // the cap check below still bounds providers that under-report.
+            ByteArrayOutputStream out = new ByteArrayOutputStream(sizeHint > 0 ? (int) sizeHint : 256 * 1024);
             out.write(header, 0, headerLength);
             byte[] buffer = new byte[64 * 1024];
             int read;
@@ -291,6 +306,27 @@ public class FileUploaderPlugin extends Plugin {
             }
             return out.toByteArray();
         }
+    }
+
+    /** Size in bytes reported by the content provider or filesystem, or -1 when unknown. */
+    private long queryContentSize(Uri uri) {
+        if ("file".equals(uri.getScheme())) {
+            String path = uri.getPath();
+            long length = path != null ? new File(path).length() : 0;
+            return length > 0 ? length : -1;
+        }
+        try (Cursor cursor =
+                getContext()
+                        .getContentResolver()
+                        .query(uri, new String[] {OpenableColumns.SIZE}, null, null, null)) {
+            if (cursor != null && cursor.moveToFirst() && !cursor.isNull(0)) {
+                long size = cursor.getLong(0);
+                return size > 0 ? size : -1;
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Could not query picked file size", e);
+        }
+        return -1;
     }
 
     private void tryProvidersSequentially(Uri fileUri, List<String> providerOrder, PluginCall call) {

--- a/android/app/src/main/java/fivechan/android/FileUploaderPlugin.java
+++ b/android/app/src/main/java/fivechan/android/FileUploaderPlugin.java
@@ -17,7 +17,9 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -177,8 +179,27 @@ public class FileUploaderPlugin extends Plugin {
 
         new Thread(
                         () -> {
+                            File strippedFile = null;
                             try {
-                                tryProvidersSequentially(uri, providerOrder, call);
+                                StrippedPickedMedia stripped = stripPickedMediaMetadata(uri);
+                                if (stripped == null) {
+                                    tryProvidersSequentially(uri, providerOrder, call);
+                                    return;
+                                }
+                                // Route stripped images like a generated upload (cache file for
+                                // catbox, bytes for WebView injection) so the original picked URI
+                                // is never handed to a provider page. Display name and mime type
+                                // stay those of the original file.
+                                strippedFile =
+                                        FileUtils.writeBytesToCacheFile(
+                                                getContext(), stripped.fileName, stripped.bytes);
+                                tryProvidersSequentially(
+                                        Uri.fromFile(strippedFile),
+                                        providerOrder,
+                                        call,
+                                        stripped.fileName,
+                                        stripped.bytes,
+                                        stripped.mimeType);
                             } catch (Exception e) {
                                 Log.e(TAG, "Upload failed", e);
                                 try {
@@ -186,9 +207,90 @@ public class FileUploaderPlugin extends Plugin {
                                 } catch (Exception rejectEx) {
                                     Log.e(TAG, "Failed to reject call", rejectEx);
                                 }
+                            } finally {
+                                if (strippedFile != null && strippedFile.exists() && !strippedFile.delete()) {
+                                    Log.w(TAG, "Could not delete stripped upload cache file: " + strippedFile.getAbsolutePath());
+                                }
                             }
                         })
                 .start();
+    }
+
+    /** Stripped copy of a picked file plus the original file's display name and mime type. */
+    private static final class StrippedPickedMedia {
+        final byte[] bytes;
+        final String fileName;
+        final String mimeType;
+
+        StrippedPickedMedia(byte[] bytes, String fileName, String mimeType) {
+            this.bytes = bytes;
+            this.fileName = fileName;
+            this.mimeType = mimeType;
+        }
+    }
+
+    /**
+     * Reads a picked JPEG/PNG/WebP and returns a losslessly metadata-stripped copy
+     * (EXIF/GPS, XMP, IPTC, comments removed). Returns null when the file should
+     * upload unchanged instead: GIF, video, or unknown formats, files over the
+     * size cap, files with nothing to remove, or any read/parse failure —
+     * stripping must never break an upload.
+     */
+    private StrippedPickedMedia stripPickedMediaMetadata(Uri uri) {
+        try {
+            byte[] original = readStrippableBytes(uri);
+            if (original == null) {
+                return null;
+            }
+            byte[] strippedBytes = MediaMetadataStripper.stripBytes(original);
+            if (strippedBytes == null) {
+                return null;
+            }
+            String mimeType = getContext().getContentResolver().getType(uri);
+            if (mimeType == null || mimeType.isEmpty()) {
+                mimeType = MediaMetadataStripper.sniffMimeType(strippedBytes);
+            }
+            return new StrippedPickedMedia(strippedBytes, getFileName(uri), mimeType);
+        } catch (Exception e) {
+            Log.w(TAG, "Metadata strip failed, uploading picked file unchanged", e);
+            return null;
+        }
+    }
+
+    /**
+     * Fully reads the picked file when its magic bytes denote a strippable image
+     * within the size cap; returns null otherwise so GIF/video/unknown files are
+     * never loaded into memory.
+     */
+    private byte[] readStrippableBytes(Uri uri) throws Exception {
+        try (InputStream input = getContext().getContentResolver().openInputStream(uri)) {
+            if (input == null) {
+                return null;
+            }
+            byte[] header = new byte[16];
+            int headerLength = 0;
+            while (headerLength < header.length) {
+                int read = input.read(header, headerLength, header.length - headerLength);
+                if (read == -1) {
+                    break;
+                }
+                headerLength += read;
+            }
+            if (!MediaMetadataStripper.isStrippableFormat(header, headerLength)) {
+                return null;
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            out.write(header, 0, headerLength);
+            byte[] buffer = new byte[64 * 1024];
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                if (out.size() + read > MediaMetadataStripper.MAX_PROCESSABLE_BYTES) {
+                    return null;
+                }
+                out.write(buffer, 0, read);
+            }
+            return out.toByteArray();
+        }
     }
 
     private void tryProvidersSequentially(Uri fileUri, List<String> providerOrder, PluginCall call) {

--- a/android/app/src/main/java/fivechan/android/MediaMetadataStripper.java
+++ b/android/app/src/main/java/fivechan/android/MediaMetadataStripper.java
@@ -12,7 +12,9 @@ import java.util.Set;
  * byte-level implementations in sync). Removes privacy-sensitive metadata
  * (EXIF/GPS, XMP, IPTC, comments) from JPEG/PNG/WebP before any upload
  * provider sees the bytes. Containers are rewritten losslessly; pixel data is
- * never re-encoded. GIF, video, and unknown formats are not handled, and any
+ * never re-encoded, so the JPEG Exif Orientation tag (rotation lives in
+ * metadata, not pixels) is re-emitted as a minimal APP1 to keep photos from
+ * rendering sideways. GIF, video, and unknown formats are not handled, and any
  * parse anomaly returns null so callers upload the original unchanged and an
  * upload is never blocked.
  *
@@ -38,6 +40,9 @@ final class MediaMetadataStripper {
 
     /** VP8X header flag bits announcing EXIF (0x08) and XMP (0x04) chunks. */
     private static final int WEBP_VP8X_METADATA_FLAGS = 0x0c;
+
+    /** "Exif\0\0" — the payload prefix distinguishing an Exif APP1 from XMP. */
+    private static final int[] EXIF_APP1_HEADER = {0x45, 0x78, 0x69, 0x66, 0x00, 0x00};
 
     private MediaMetadataStripper() {}
 
@@ -98,9 +103,10 @@ final class MediaMetadataStripper {
 
     private static byte[] stripJpeg(byte[] bytes) {
         int len = bytes.length;
-        ByteArrayOutputStream kept = new ByteArrayOutputStream();
+        ByteArrayOutputStream kept = new ByteArrayOutputStream(len);
         kept.write(bytes, 0, 2);
         int removedBytes = 0;
+        int orientation = 0;
         int pos = 2;
 
         for (; ; ) {
@@ -114,7 +120,11 @@ final class MediaMetadataStripper {
             if (marker == 0xda) {
                 // SOS: entropy-coded data follows and contains 0xff bytes that are not
                 // segment markers, so copy verbatim to EOF instead of parsing. This
-                // also preserves data deliberately appended after EOI.
+                // also preserves data deliberately appended after EOI. Marker segments
+                // after the first SOS are deliberately left untouched: cameras write
+                // metadata before the first scan, and parsing entropy-coded data risks
+                // degrading exotic-but-valid files (e.g. motion-photo trailers) into
+                // full pass-through, which would strip less than this does.
                 kept.write(bytes, pos, len - pos);
                 break;
             }
@@ -129,6 +139,9 @@ final class MediaMetadataStripper {
 
             // Dropped segments: APP1 (Exif and XMP), APP13 (IPTC/Photoshop), COM.
             if (marker == 0xe1 || marker == 0xed || marker == 0xfe) {
+                if (marker == 0xe1 && orientation == 0 && isExifApp1Payload(bytes, markerPos + 3, (int) end)) {
+                    orientation = readExifOrientation(bytes, markerPos + 9, (int) end);
+                }
                 removedBytes += (int) end - pos;
             } else {
                 kept.write(bytes, pos, (int) end - pos);
@@ -137,12 +150,87 @@ final class MediaMetadataStripper {
         }
 
         if (removedBytes == 0) return null;
-        return kept.toByteArray();
+        byte[] out = kept.toByteArray();
+        if (orientation < 2 || orientation > 8) return out;
+        // Rotation lives in metadata, not pixels: re-emit the Orientation tag (and
+        // nothing else) as a minimal APP1 after SOI so photos don't render sideways.
+        byte[] segment = buildOrientationApp1(orientation);
+        byte[] withOrientation = new byte[out.length + segment.length];
+        System.arraycopy(out, 0, withOrientation, 0, 2);
+        System.arraycopy(segment, 0, withOrientation, 2, segment.length);
+        System.arraycopy(out, 2, withOrientation, 2 + segment.length, out.length - 2);
+        return withOrientation;
+    }
+
+    private static boolean isExifApp1Payload(byte[] bytes, int start, int end) {
+        if (start + EXIF_APP1_HEADER.length > end) {
+            return false;
+        }
+        for (int i = 0; i < EXIF_APP1_HEADER.length; i++) {
+            if (u8(bytes, start + i) != EXIF_APP1_HEADER[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /** Reads the Orientation tag (1-8) from IFD0 of an Exif TIFF block, or 0 when absent or malformed. */
+    private static int readExifOrientation(byte[] bytes, int tiffStart, int end) {
+        if (tiffStart + 8 > end) return 0;
+        boolean little;
+        if (u8(bytes, tiffStart) == 0x49 && u8(bytes, tiffStart + 1) == 0x49) little = true;
+        else if (u8(bytes, tiffStart) == 0x4d && u8(bytes, tiffStart + 1) == 0x4d) little = false;
+        else return 0;
+        if (readTiffU16(bytes, tiffStart + 2, little) != 42) return 0;
+        long ifdOffset = readTiffU32(bytes, tiffStart + 4, little);
+        if (ifdOffset < 8) return 0;
+        long ifdPos = tiffStart + ifdOffset;
+        if (ifdPos + 2 > end) return 0;
+        int entryCount = readTiffU16(bytes, (int) ifdPos, little);
+        for (int i = 0; i < entryCount; i++) {
+            long entry = ifdPos + 2 + i * 12L;
+            if (entry + 12 > end) return 0;
+            if (readTiffU16(bytes, (int) entry, little) != 0x0112) continue;
+            // Orientation must be a single SHORT; the value sits in the first two payload bytes.
+            if (readTiffU16(bytes, (int) entry + 2, little) != 3) return 0;
+            if (readTiffU32(bytes, (int) entry + 4, little) != 1) return 0;
+            int value = readTiffU16(bytes, (int) entry + 8, little);
+            return value >= 1 && value <= 8 ? value : 0;
+        }
+        return 0;
+    }
+
+    private static int readTiffU16(byte[] bytes, int pos, boolean little) {
+        return little ? u8(bytes, pos) | (u8(bytes, pos + 1) << 8) : (u8(bytes, pos) << 8) | u8(bytes, pos + 1);
+    }
+
+    private static long readTiffU32(byte[] bytes, int pos, boolean little) {
+        return little
+                ? u8(bytes, pos)
+                        | ((long) u8(bytes, pos + 1) << 8)
+                        | ((long) u8(bytes, pos + 2) << 16)
+                        | ((long) u8(bytes, pos + 3) << 24)
+                : ((long) u8(bytes, pos) << 24)
+                        | ((long) u8(bytes, pos + 1) << 16)
+                        | ((long) u8(bytes, pos + 2) << 8)
+                        | u8(bytes, pos + 3);
+    }
+
+    /** Minimal little-endian Exif APP1 whose IFD0 holds only the Orientation tag. */
+    private static byte[] buildOrientationApp1(int orientation) {
+        return new byte[] {
+            (byte) 0xff, (byte) 0xe1, 0x00, 0x22, // APP1, length 34
+            0x45, 0x78, 0x69, 0x66, 0x00, 0x00, // "Exif\0\0"
+            0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, // "II", 42, IFD0 at offset 8
+            0x01, 0x00, // one IFD entry
+            0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, (byte) orientation, 0x00, 0x00, 0x00, // Orientation, SHORT x1
+            0x00, 0x00, 0x00, 0x00, // no next IFD
+        };
     }
 
     private static byte[] stripPng(byte[] bytes) {
         int len = bytes.length;
-        ByteArrayOutputStream kept = new ByteArrayOutputStream();
+        ByteArrayOutputStream kept = new ByteArrayOutputStream(len);
         kept.write(bytes, 0, 8);
         int removedBytes = 0;
         int pos = 8;
@@ -180,7 +268,7 @@ final class MediaMetadataStripper {
         long riffEnd = 8 + readU32le(bytes, 4);
         if (riffEnd < 12 || riffEnd > len) return null;
 
-        ByteArrayOutputStream kept = new ByteArrayOutputStream();
+        ByteArrayOutputStream kept = new ByteArrayOutputStream(len);
         kept.write(bytes, 0, 12);
         int outLength = 12;
         int removedBytes = 0;

--- a/android/app/src/main/java/fivechan/android/MediaMetadataStripper.java
+++ b/android/app/src/main/java/fivechan/android/MediaMetadataStripper.java
@@ -1,0 +1,255 @@
+package fivechan.android;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Media metadata stripping for files picked on the device, where the native
+ * plugin uploads directly and the renderer-side stripper never sees the bytes
+ * (parity with src/lib/media-metadata/strip-media-metadata.ts — keep the two
+ * byte-level implementations in sync). Removes privacy-sensitive metadata
+ * (EXIF/GPS, XMP, IPTC, comments) from JPEG/PNG/WebP before any upload
+ * provider sees the bytes. Containers are rewritten losslessly; pixel data is
+ * never re-encoded. GIF, video, and unknown formats are not handled, and any
+ * parse anomaly returns null so callers upload the original unchanged and an
+ * upload is never blocked.
+ *
+ * <p>Deliberately pure Java (no android.* imports) so it runs in JVM unit tests.
+ */
+final class MediaMetadataStripper {
+
+    /** Files larger than this pass through untouched to avoid large in-memory copies. */
+    static final int MAX_PROCESSABLE_BYTES = 64 * 1024 * 1024;
+
+    private static final int[] PNG_SIGNATURE = {0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a};
+
+    /**
+     * PNG ancillary chunks kept because they affect rendering (plus APNG frames).
+     * Critical chunks are always kept; ancillary chunks not listed here (tEXt,
+     * zTXt, iTXt, eXIf, tIME, and unknown ones) are dropped.
+     */
+    private static final Set<String> PNG_KEPT_ANCILLARY_CHUNKS =
+            new HashSet<>(
+                    Arrays.asList(
+                            "tRNS", "gAMA", "cHRM", "sRGB", "iCCP", "sBIT", "bKGD", "pHYs", "acTL",
+                            "fcTL", "fdAT"));
+
+    /** VP8X header flag bits announcing EXIF (0x08) and XMP (0x04) chunks. */
+    private static final int WEBP_VP8X_METADATA_FLAGS = 0x0c;
+
+    private MediaMetadataStripper() {}
+
+    /**
+     * True when the leading {@code length} bytes denote a format stripBytes handles
+     * (JPEG, PNG, WebP), so callers can skip reading GIF/video/unknown files fully.
+     */
+    static boolean isStrippableFormat(byte[] bytes, int length) {
+        return isJpeg(bytes, length) || isPng(bytes, length) || isWebp(bytes, length);
+    }
+
+    /** Mime type by magic bytes for the formats stripBytes handles, or null. */
+    static String sniffMimeType(byte[] bytes) {
+        if (isJpeg(bytes, bytes.length)) return "image/jpeg";
+        if (isPng(bytes, bytes.length)) return "image/png";
+        if (isWebp(bytes, bytes.length)) return "image/webp";
+        return null;
+    }
+
+    /**
+     * Detects the format by magic bytes (mime/extension are never trusted) and
+     * returns a stripped copy, or null meaning "keep original".
+     */
+    static byte[] stripBytes(byte[] bytes) {
+        if (isJpeg(bytes, bytes.length)) {
+            return stripJpeg(bytes);
+        }
+        if (isPng(bytes, bytes.length)) {
+            return stripPng(bytes);
+        }
+        if (isWebp(bytes, bytes.length)) {
+            return stripWebp(bytes);
+        }
+        // GIF passes through deliberately (rewriting animations is risky and GIFs
+        // carry no GPS-class metadata); video and unknown formats pass through too.
+        return null;
+    }
+
+    private static boolean isJpeg(byte[] bytes, int length) {
+        return length >= 4 && u8(bytes, 0) == 0xff && u8(bytes, 1) == 0xd8 && u8(bytes, 2) == 0xff;
+    }
+
+    private static boolean isPng(byte[] bytes, int length) {
+        if (length < 8) {
+            return false;
+        }
+        for (int i = 0; i < PNG_SIGNATURE.length; i++) {
+            if (u8(bytes, i) != PNG_SIGNATURE[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isWebp(byte[] bytes, int length) {
+        return length >= 16 && "RIFF".equals(readFourCc(bytes, 0)) && "WEBP".equals(readFourCc(bytes, 8));
+    }
+
+    private static byte[] stripJpeg(byte[] bytes) {
+        int len = bytes.length;
+        ByteArrayOutputStream kept = new ByteArrayOutputStream();
+        kept.write(bytes, 0, 2);
+        int removedBytes = 0;
+        int pos = 2;
+
+        for (; ; ) {
+            if (pos + 1 >= len || u8(bytes, pos) != 0xff) return null;
+            // A marker may be preceded by any number of 0xff fill bytes.
+            int markerPos = pos + 1;
+            while (markerPos < len && u8(bytes, markerPos) == 0xff) markerPos++;
+            if (markerPos >= len) return null;
+            int marker = u8(bytes, markerPos);
+
+            if (marker == 0xda) {
+                // SOS: entropy-coded data follows and contains 0xff bytes that are not
+                // segment markers, so copy verbatim to EOF instead of parsing. This
+                // also preserves data deliberately appended after EOI.
+                kept.write(bytes, pos, len - pos);
+                break;
+            }
+            // Standalone markers (TEM, RST, SOI, EOI) are not expected before SOS.
+            if (marker == 0x00 || marker == 0x01 || (marker >= 0xd0 && marker <= 0xd9)) return null;
+
+            if (markerPos + 2 >= len) return null;
+            int segmentLength = (u8(bytes, markerPos + 1) << 8) | u8(bytes, markerPos + 2);
+            if (segmentLength < 2) return null;
+            long end = (long) markerPos + 1 + segmentLength;
+            if (end > len) return null;
+
+            // Dropped segments: APP1 (Exif and XMP), APP13 (IPTC/Photoshop), COM.
+            if (marker == 0xe1 || marker == 0xed || marker == 0xfe) {
+                removedBytes += (int) end - pos;
+            } else {
+                kept.write(bytes, pos, (int) end - pos);
+            }
+            pos = (int) end;
+        }
+
+        if (removedBytes == 0) return null;
+        return kept.toByteArray();
+    }
+
+    private static byte[] stripPng(byte[] bytes) {
+        int len = bytes.length;
+        ByteArrayOutputStream kept = new ByteArrayOutputStream();
+        kept.write(bytes, 0, 8);
+        int removedBytes = 0;
+        int pos = 8;
+
+        for (; ; ) {
+            if (pos + 8 > len) return null; // ran out of bytes before IEND
+            long dataLength = readU32be(bytes, pos);
+            if (dataLength > 0x7fffffffL) return null;
+            long end = pos + 12L + dataLength; // length + type + data + CRC
+            if (end > len) return null;
+            String type = readFourCc(bytes, pos + 4);
+
+            if ("IEND".equals(type)) {
+                // Keep IEND and any deliberately appended trailing data verbatim.
+                kept.write(bytes, pos, len - pos);
+                break;
+            }
+
+            boolean isCritical = (u8(bytes, pos + 4) & 0x20) == 0;
+            if (isCritical || PNG_KEPT_ANCILLARY_CHUNKS.contains(type)) {
+                // Chunks are copied whole so their CRCs remain valid.
+                kept.write(bytes, pos, (int) end - pos);
+            } else {
+                removedBytes += (int) end - pos;
+            }
+            pos = (int) end;
+        }
+
+        if (removedBytes == 0) return null;
+        return kept.toByteArray();
+    }
+
+    private static byte[] stripWebp(byte[] bytes) {
+        int len = bytes.length;
+        long riffEnd = 8 + readU32le(bytes, 4);
+        if (riffEnd < 12 || riffEnd > len) return null;
+
+        ByteArrayOutputStream kept = new ByteArrayOutputStream();
+        kept.write(bytes, 0, 12);
+        int outLength = 12;
+        int removedBytes = 0;
+        int vp8xFlagsOffset = -1;
+        boolean vp8xHasMetadataFlags = false;
+        int pos = 12;
+
+        while (pos < riffEnd) {
+            if (pos + 8 > riffEnd) return null;
+            String fourCc = readFourCc(bytes, pos);
+            long chunkSize = readU32le(bytes, pos + 4);
+            long end = pos + 8 + chunkSize + (chunkSize & 1); // chunks are padded to even sizes
+            if (end > riffEnd) return null;
+
+            if ("EXIF".equals(fourCc) || "XMP ".equals(fourCc)) {
+                removedBytes += (int) end - pos;
+            } else {
+                if ("VP8X".equals(fourCc)) {
+                    if (chunkSize < 10) return null;
+                    vp8xFlagsOffset = outLength + 8;
+                    vp8xHasMetadataFlags = (u8(bytes, pos + 8) & WEBP_VP8X_METADATA_FLAGS) != 0;
+                }
+                kept.write(bytes, pos, (int) end - pos);
+                outLength += (int) end - pos;
+            }
+            pos = (int) end;
+        }
+
+        if (removedBytes == 0 && !vp8xHasMetadataFlags) return null;
+
+        if (riffEnd < len) kept.write(bytes, (int) riffEnd, len - (int) riffEnd); // keep appended trailing data
+        byte[] out = kept.toByteArray();
+        writeU32le(out, 4, outLength - 8);
+        if (vp8xFlagsOffset >= 0) out[vp8xFlagsOffset] &= (byte) ~WEBP_VP8X_METADATA_FLAGS;
+        return out;
+    }
+
+    private static int u8(byte[] bytes, int pos) {
+        return bytes[pos] & 0xff;
+    }
+
+    private static String readFourCc(byte[] bytes, int pos) {
+        return new String(
+                new char[] {
+                    (char) u8(bytes, pos),
+                    (char) u8(bytes, pos + 1),
+                    (char) u8(bytes, pos + 2),
+                    (char) u8(bytes, pos + 3)
+                });
+    }
+
+    private static long readU32be(byte[] bytes, int pos) {
+        return ((long) u8(bytes, pos) << 24)
+                | ((long) u8(bytes, pos + 1) << 16)
+                | ((long) u8(bytes, pos + 2) << 8)
+                | u8(bytes, pos + 3);
+    }
+
+    private static long readU32le(byte[] bytes, int pos) {
+        return u8(bytes, pos)
+                | ((long) u8(bytes, pos + 1) << 8)
+                | ((long) u8(bytes, pos + 2) << 16)
+                | ((long) u8(bytes, pos + 3) << 24);
+    }
+
+    private static void writeU32le(byte[] bytes, int pos, int value) {
+        bytes[pos] = (byte) (value & 0xff);
+        bytes[pos + 1] = (byte) ((value >>> 8) & 0xff);
+        bytes[pos + 2] = (byte) ((value >>> 16) & 0xff);
+        bytes[pos + 3] = (byte) ((value >>> 24) & 0xff);
+    }
+}

--- a/android/app/src/test/java/fivechan/android/MediaMetadataStripperTest.java
+++ b/android/app/src/test/java/fivechan/android/MediaMetadataStripperTest.java
@@ -1,0 +1,297 @@
+package fivechan.android;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.zip.CRC32;
+import org.junit.Test;
+
+/**
+ * Unit tests for MediaMetadataStripper. The byte-level fixtures mirror
+ * src/lib/media-metadata/__tests__/strip-media-metadata.test.ts (and the
+ * Electron copy in electron/strip-media-metadata.test.js) so all
+ * implementations stay in lockstep.
+ */
+public class MediaMetadataStripperTest {
+
+    // --- fixture helpers ---
+
+    private static byte[] bytes(int... values) {
+        byte[] out = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            out[i] = (byte) values[i];
+        }
+        return out;
+    }
+
+    private static byte[] repeat(int value, int count) {
+        byte[] out = new byte[count];
+        Arrays.fill(out, (byte) value);
+        return out;
+    }
+
+    private static byte[] concat(byte[]... parts) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] part : parts) {
+            out.write(part, 0, part.length);
+        }
+        return out.toByteArray();
+    }
+
+    private static byte[] ascii(String text) {
+        byte[] out = new byte[text.length()];
+        for (int i = 0; i < text.length(); i++) {
+            out[i] = (byte) text.charAt(i);
+        }
+        return out;
+    }
+
+    private static byte[] u32be(long value) {
+        return bytes((int) (value >>> 24) & 0xff, (int) (value >>> 16) & 0xff, (int) (value >>> 8) & 0xff, (int) value & 0xff);
+    }
+
+    private static byte[] u32le(long value) {
+        return bytes((int) value & 0xff, (int) (value >>> 8) & 0xff, (int) (value >>> 16) & 0xff, (int) (value >>> 24) & 0xff);
+    }
+
+    private static int indexOfSequence(byte[] haystack, byte[] needle) {
+        outer:
+        for (int i = 0; i + needle.length <= haystack.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    // --- JPEG fixtures ---
+
+    private static byte[] jpegSegment(int marker, byte[] payload) {
+        int length = payload.length + 2;
+        return concat(bytes(0xff, marker, (length >> 8) & 0xff, length & 0xff), payload);
+    }
+
+    private static final byte[] SOI = bytes(0xff, 0xd8);
+    private static final byte[] APP0_JFIF = jpegSegment(0xe0, concat(ascii("JFIF"), bytes(0, 1, 1, 0, 0, 1, 0, 1, 0, 0)));
+    private static final byte[] APP1_EXIF =
+            jpegSegment(0xe1, concat(ascii("Exif"), bytes(0, 0), ascii("II*"), bytes(0), ascii("GPSLATITUDE 51.5072")));
+    private static final byte[] APP1_XMP = jpegSegment(0xe1, concat(ascii("http://ns.adobe.com/xap/1.0/"), bytes(0), ascii("<x:xmpmeta/>")));
+    private static final byte[] APP13_IPTC = jpegSegment(0xed, concat(ascii("Photoshop 3.0"), bytes(0), ascii("8BIM")));
+    private static final byte[] APP2_ICC = jpegSegment(0xe2, concat(ascii("ICC_PROFILE"), bytes(0, 1, 1, 9, 9, 9)));
+    private static final byte[] COM = jpegSegment(0xfe, ascii("shot on my phone"));
+    private static final byte[] DQT = jpegSegment(0xdb, concat(bytes(0), repeat(7, 64)));
+    private static final byte[] SOF0 = jpegSegment(0xc0, bytes(8, 0, 1, 0, 1, 1, 0x11, 0x11, 0));
+    private static final byte[] DHT = jpegSegment(0xc4, concat(bytes(0), repeat(0, 16), bytes(0x0a)));
+    // SOS header, entropy-coded data with 0xff00 stuffing, EOI, deliberately appended payload
+    private static final byte[] SOS_TO_EOF =
+            concat(bytes(0xff, 0xda, 0x00, 0x08, 1, 1, 0, 0, 63, 0, 0x12, 0xff, 0x00, 0x34, 0xab, 0xff, 0xd9), ascii("APPENDED_PAYLOAD"));
+
+    private static final byte[] JPEG_WITH_METADATA =
+            concat(SOI, APP0_JFIF, APP1_EXIF, APP1_XMP, APP13_IPTC, APP2_ICC, COM, DQT, SOF0, DHT, SOS_TO_EOF);
+    private static final byte[] JPEG_STRIPPED = concat(SOI, APP0_JFIF, APP2_ICC, DQT, SOF0, DHT, SOS_TO_EOF);
+
+    // --- PNG fixtures ---
+
+    private static byte[] pngChunk(String type, byte[] data) {
+        byte[] typeBytes = ascii(type);
+        CRC32 crc = new CRC32();
+        crc.update(typeBytes);
+        crc.update(data);
+        return concat(u32be(data.length), typeBytes, data, u32be(crc.getValue()));
+    }
+
+    private static final byte[] PNG_SIGNATURE = bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
+    private static final byte[] IHDR = pngChunk("IHDR", concat(u32be(1), u32be(1), bytes(8, 6, 0, 0, 0)));
+    private static final byte[] TEXT = pngChunk("tEXt", concat(ascii("Comment"), bytes(0), ascii("gps: 51.5, -0.1")));
+    private static final byte[] ZTXT = pngChunk("zTXt", concat(ascii("Author"), bytes(0, 0, 1, 2, 3)));
+    private static final byte[] ITXT = pngChunk("iTXt", concat(ascii("XML:com.adobe.xmp"), bytes(0, 0, 0, 0, 0), ascii("<xmp/>")));
+    private static final byte[] EXIF_CHUNK = pngChunk("eXIf", concat(ascii("II*"), bytes(0, 1, 2, 3)));
+    private static final byte[] TIME = pngChunk("tIME", bytes(7, 0xe8, 1, 1, 0, 0, 0));
+    private static final byte[] UNKNOWN_ANCILLARY = pngChunk("prVt", ascii("secret"));
+    private static final byte[] PHYS = pngChunk("pHYs", concat(u32be(2835), u32be(2835), bytes(1)));
+    private static final byte[] IDAT = pngChunk("IDAT", bytes(0x78, 0x9c, 1, 2, 3, 4));
+    private static final byte[] IEND = pngChunk("IEND", bytes());
+    private static final byte[] PNG_TRAILER = ascii("TRAILING_DATA");
+
+    private static final byte[] PNG_WITH_METADATA =
+            concat(PNG_SIGNATURE, IHDR, TEXT, ZTXT, ITXT, EXIF_CHUNK, TIME, UNKNOWN_ANCILLARY, PHYS, IDAT, IEND, PNG_TRAILER);
+    private static final byte[] PNG_STRIPPED = concat(PNG_SIGNATURE, IHDR, PHYS, IDAT, IEND, PNG_TRAILER);
+
+    // --- WebP fixtures ---
+
+    private static byte[] webpChunk(String fourCc, byte[] data) {
+        byte[] padded = data.length % 2 == 1 ? concat(data, bytes(0)) : data;
+        return concat(ascii(fourCc), u32le(data.length), padded);
+    }
+
+    private static byte[] riffWebp(byte[]... chunks) {
+        byte[] payload = concat(chunks);
+        return concat(ascii("RIFF"), u32le(4 + payload.length), ascii("WEBP"), payload);
+    }
+
+    // flags: ALPHA (0x10) | EXIF (0x08) | XMP (0x04)
+    private static final byte[] VP8X = webpChunk("VP8X", bytes(0x1c, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+    private static final byte[] VP8X_CLEARED = webpChunk("VP8X", bytes(0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+    private static final byte[] ICCP = webpChunk("ICCP", bytes(1, 2, 3, 4, 5)); // odd size exercises padding
+    private static final byte[] WEBP_EXIF = webpChunk("EXIF", concat(ascii("II*"), bytes(0, 0x99))); // odd size exercises padding
+    private static final byte[] WEBP_XMP = webpChunk("XMP ", ascii("<x:xmpmeta/>"));
+    private static final byte[] VP8 = webpChunk("VP8 ", bytes(0x30, 1, 0, 0x9d, 0x01, 0x2a, 1, 0, 1, 0));
+
+    private static final byte[] WEBP_WITH_METADATA = riffWebp(VP8X, ICCP, WEBP_EXIF, WEBP_XMP, VP8);
+    private static final byte[] WEBP_STRIPPED = riffWebp(VP8X_CLEARED, ICCP, VP8);
+
+    private static final byte[] GIF_WITH_COMMENT =
+            concat(ascii("GIF89a"), bytes(1, 0, 1, 0, 0x91, 0, 0, 0x21, 0xfe, 4), ascii("gps!"), bytes(0, 0x3b));
+
+    // --- JPEG ---
+
+    @Test
+    public void jpeg_removesMetadataSegments_keepsApp0App2AndCodingSegments() {
+        assertArrayEquals(JPEG_STRIPPED, MediaMetadataStripper.stripBytes(JPEG_WITH_METADATA));
+    }
+
+    @Test
+    public void jpeg_copiesSosOnwardVerbatim_includingDataAppendedAfterEoi() {
+        byte[] output = MediaMetadataStripper.stripBytes(JPEG_WITH_METADATA);
+
+        assertArrayEquals(SOS_TO_EOF, Arrays.copyOfRange(output, output.length - SOS_TO_EOF.length, output.length));
+        byte[] appended = ascii("APPENDED_PAYLOAD");
+        assertArrayEquals(appended, Arrays.copyOfRange(output, output.length - appended.length, output.length));
+    }
+
+    @Test
+    public void jpeg_returnsNullWhenThereIsNoMetadataToRemove() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(SOI, APP0_JFIF, DQT, SOF0, DHT, SOS_TO_EOF)));
+    }
+
+    @Test
+    public void jpeg_returnsNullWhenSegmentLengthOverrunsFile() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(SOI, bytes(0xff, 0xe1, 0xff, 0xff, 1, 2, 3))));
+    }
+
+    @Test
+    public void jpeg_returnsNullWhenSosIsNeverReached() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(SOI, APP1_EXIF, DQT)));
+    }
+
+    @Test
+    public void jpeg_returnsNullWhenMarkerStructureIsInvalid() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(SOI, bytes(0x00, 0x01, 0x02, 0x03))));
+    }
+
+    // --- PNG ---
+
+    @Test
+    public void png_removesMetadataChunks_keepsListedChunks() {
+        assertArrayEquals(PNG_STRIPPED, MediaMetadataStripper.stripBytes(PNG_WITH_METADATA));
+    }
+
+    @Test
+    public void png_keepsCriticalChunksAndDataAppendedAfterIend() {
+        byte[] output = MediaMetadataStripper.stripBytes(PNG_WITH_METADATA);
+
+        assertArrayEquals(PNG_SIGNATURE, Arrays.copyOfRange(output, 0, 8));
+        for (byte[] chunk : new byte[][] {IHDR, IDAT, IEND}) {
+            assertTrue(indexOfSequence(output, chunk) >= 0);
+        }
+        assertArrayEquals(PNG_TRAILER, Arrays.copyOfRange(output, output.length - PNG_TRAILER.length, output.length));
+    }
+
+    @Test
+    public void png_returnsNullWhenThereIsNoMetadataToRemove() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(PNG_SIGNATURE, IHDR, IDAT, IEND)));
+    }
+
+    @Test
+    public void png_returnsNullWhenChunkLengthOverrunsFile() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(PNG_SIGNATURE, u32be(9999), ascii("tEXt"), bytes(1, 2, 3))));
+    }
+
+    @Test
+    public void png_returnsNullWhenIendIsMissing() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(PNG_SIGNATURE, IHDR, TEXT, IDAT)));
+    }
+
+    // --- WebP ---
+
+    @Test
+    public void webp_removesExifAndXmpChunks_clearsVp8xFlags_fixesRiffSize() {
+        assertArrayEquals(WEBP_STRIPPED, MediaMetadataStripper.stripBytes(WEBP_WITH_METADATA));
+    }
+
+    @Test
+    public void webp_clearsVp8xMetadataFlagsEvenWithoutExifOrXmpChunk() {
+        assertArrayEquals(riffWebp(VP8X_CLEARED, VP8), MediaMetadataStripper.stripBytes(riffWebp(VP8X, VP8)));
+    }
+
+    @Test
+    public void webp_returnsNullWhenThereIsNoMetadataToRemove() {
+        assertNull(MediaMetadataStripper.stripBytes(riffWebp(VP8)));
+    }
+
+    @Test
+    public void webp_returnsNullWhenRiffSizeOverrunsFile() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(ascii("RIFF"), u32le(9999), ascii("WEBP"), VP8)));
+    }
+
+    @Test
+    public void webp_returnsNullWhenChunkOverrunsRiffPayload() {
+        assertNull(MediaMetadataStripper.stripBytes(riffWebp(Arrays.copyOf(webpChunk("EXIF", bytes(1, 2)), 8))));
+    }
+
+    // --- pass-through formats ---
+
+    @Test
+    public void passThrough_returnsNullForGif() {
+        assertNull(MediaMetadataStripper.stripBytes(GIF_WITH_COMMENT));
+    }
+
+    @Test
+    public void passThrough_returnsNullForMp4() {
+        assertNull(MediaMetadataStripper.stripBytes(concat(u32be(0x18), ascii("ftypmp42"), repeat(0, 16))));
+    }
+
+    @Test
+    public void passThrough_returnsNullForWebm() {
+        assertNull(MediaMetadataStripper.stripBytes(bytes(0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4)));
+    }
+
+    @Test
+    public void passThrough_returnsNullForUnknownFormats() {
+        assertNull(MediaMetadataStripper.stripBytes(ascii("not an image at all")));
+    }
+
+    @Test
+    public void passThrough_returnsNullForEmptyInput() {
+        assertNull(MediaMetadataStripper.stripBytes(bytes()));
+    }
+
+    // --- header sniffing helpers used by the plugin's read path ---
+
+    @Test
+    public void isStrippableFormat_recognizesJpegPngWebpHeaders() {
+        assertTrue(MediaMetadataStripper.isStrippableFormat(JPEG_WITH_METADATA, 16));
+        assertTrue(MediaMetadataStripper.isStrippableFormat(PNG_WITH_METADATA, 16));
+        assertTrue(MediaMetadataStripper.isStrippableFormat(WEBP_WITH_METADATA, 16));
+    }
+
+    @Test
+    public void isStrippableFormat_rejectsPassThroughFormatsAndShortHeaders() {
+        assertFalse(MediaMetadataStripper.isStrippableFormat(GIF_WITH_COMMENT, 16));
+        assertFalse(MediaMetadataStripper.isStrippableFormat(JPEG_WITH_METADATA, 3)); // jpeg needs at least 4 bytes
+        assertFalse(MediaMetadataStripper.isStrippableFormat(WEBP_WITH_METADATA, 15)); // webp needs at least 16 bytes
+        assertFalse(MediaMetadataStripper.isStrippableFormat(bytes(), 0));
+    }
+
+    @Test
+    public void sniffMimeType_reportsMimeByMagicBytes() {
+        assertEquals("image/jpeg", MediaMetadataStripper.sniffMimeType(JPEG_STRIPPED));
+        assertEquals("image/png", MediaMetadataStripper.sniffMimeType(PNG_STRIPPED));
+        assertEquals("image/webp", MediaMetadataStripper.sniffMimeType(WEBP_STRIPPED));
+        assertNull(MediaMetadataStripper.sniffMimeType(GIF_WITH_COMMENT));
+    }
+}

--- a/android/app/src/test/java/fivechan/android/MediaMetadataStripperTest.java
+++ b/android/app/src/test/java/fivechan/android/MediaMetadataStripperTest.java
@@ -94,6 +94,36 @@ public class MediaMetadataStripperTest {
             concat(SOI, APP0_JFIF, APP1_EXIF, APP1_XMP, APP13_IPTC, APP2_ICC, COM, DQT, SOF0, DHT, SOS_TO_EOF);
     private static final byte[] JPEG_STRIPPED = concat(SOI, APP0_JFIF, APP2_ICC, DQT, SOF0, DHT, SOS_TO_EOF);
 
+    /** Valid Exif APP1 whose IFD0 holds a Make entry (exercises the walk) and an Orientation entry. */
+    private static byte[] exifApp1WithOrientation(int orientation, boolean littleEndian) {
+        byte[] tiff =
+                littleEndian
+                        ? concat(
+                                bytes(0x49, 0x49, 0x2a, 0x00), u32le(8), // "II", 42, IFD0 at offset 8
+                                bytes(0x02, 0x00), // two entries
+                                bytes(0x0f, 0x01, 0x02, 0x00), u32le(4), ascii("abc"), bytes(0x00), // Make, ASCII x4 inline
+                                bytes(0x12, 0x01, 0x03, 0x00), u32le(1), bytes(orientation, 0x00, 0x00, 0x00), // Orientation, SHORT x1
+                                u32le(0)) // no next IFD
+                        : concat(
+                                bytes(0x4d, 0x4d, 0x00, 0x2a), u32be(8), // "MM", 42, IFD0 at offset 8
+                                bytes(0x00, 0x02),
+                                bytes(0x01, 0x0f, 0x00, 0x02), u32be(4), ascii("abc"), bytes(0x00),
+                                bytes(0x01, 0x12, 0x00, 0x03), u32be(1), bytes(0x00, orientation, 0x00, 0x00),
+                                u32be(0));
+        return jpegSegment(0xe1, concat(ascii("Exif"), bytes(0, 0), tiff));
+    }
+
+    /** The minimal APP1 the stripper is expected to synthesize (always little-endian). */
+    private static byte[] orientationApp1(int orientation) {
+        return concat(
+                bytes(0xff, 0xe1, 0x00, 0x22),
+                ascii("Exif"), bytes(0, 0),
+                bytes(0x49, 0x49, 0x2a, 0x00), u32le(8),
+                bytes(0x01, 0x00),
+                bytes(0x12, 0x01, 0x03, 0x00), u32le(1), bytes(orientation, 0x00, 0x00, 0x00),
+                u32le(0));
+    }
+
     // --- PNG fixtures ---
 
     private static byte[] pngChunk(String type, byte[] data) {
@@ -181,6 +211,32 @@ public class MediaMetadataStripperTest {
     @Test
     public void jpeg_returnsNullWhenMarkerStructureIsInvalid() {
         assertNull(MediaMetadataStripper.stripBytes(concat(SOI, bytes(0x00, 0x01, 0x02, 0x03))));
+    }
+
+    @Test
+    public void jpeg_reEmitsExifOrientationAsMinimalApp1() {
+        byte[] jpeg = concat(SOI, APP0_JFIF, exifApp1WithOrientation(6, true), COM, DQT, SOF0, DHT, SOS_TO_EOF);
+        byte[] expected = concat(SOI, orientationApp1(6), APP0_JFIF, DQT, SOF0, DHT, SOS_TO_EOF);
+        assertArrayEquals(expected, MediaMetadataStripper.stripBytes(jpeg));
+    }
+
+    @Test
+    public void jpeg_readsBigEndianExifAndReEmitsLittleEndian() {
+        byte[] jpeg = concat(SOI, exifApp1WithOrientation(3, false), DQT, SOF0, DHT, SOS_TO_EOF);
+        byte[] expected = concat(SOI, orientationApp1(3), DQT, SOF0, DHT, SOS_TO_EOF);
+        assertArrayEquals(expected, MediaMetadataStripper.stripBytes(jpeg));
+    }
+
+    @Test
+    public void jpeg_doesNotReEmitDefaultOrientation1() {
+        byte[] jpeg = concat(SOI, exifApp1WithOrientation(1, true), DQT, SOF0, DHT, SOS_TO_EOF);
+        assertArrayEquals(concat(SOI, DQT, SOF0, DHT, SOS_TO_EOF), MediaMetadataStripper.stripBytes(jpeg));
+    }
+
+    @Test
+    public void jpeg_doesNotReEmitOutOfRangeOrientation() {
+        byte[] jpeg = concat(SOI, exifApp1WithOrientation(9, true), DQT, SOF0, DHT, SOS_TO_EOF);
+        assertArrayEquals(concat(SOI, DQT, SOF0, DHT, SOS_TO_EOF), MediaMetadataStripper.stripBytes(jpeg));
     }
 
     // --- PNG ---

--- a/electron/main.js
+++ b/electron/main.js
@@ -423,7 +423,8 @@ ipcMain.handle('automate-upload-media', async (event, options) => {
     return await automateUploadMedia({ provider, filePath: prepared.filePath });
   } finally {
     if (prepared.tempDir) {
-      await fs.promises.rm(prepared.tempDir, { force: true, recursive: true });
+      // Best-effort cleanup: a failed rm must not reject a successful upload.
+      await fs.promises.rm(prepared.tempDir, { force: true, recursive: true }).catch(() => {});
     }
   }
 });
@@ -438,7 +439,8 @@ ipcMain.handle('automate-upload-generated-media', async (event, options) => {
   try {
     return await automateUploadMedia({ provider, filePath });
   } finally {
-    await fs.promises.rm(tempDir, { force: true, recursive: true });
+    // Best-effort cleanup: a failed rm must not reject a successful upload.
+    await fs.promises.rm(tempDir, { force: true, recursive: true }).catch(() => {});
   }
 });
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,7 @@
 import './log.js';
 import { app, BrowserWindow, Menu, MenuItem, Tray, shell, dialog, nativeTheme, nativeImage, ipcMain, clipboard } from 'electron';
 import { automateUploadMedia } from './media-upload-automation.js';
+import { prepareStrippedUploadFile } from './strip-media-metadata.js';
 import { downloadAndInstallUpdate } from './app-updater.js';
 import isDev from 'electron-is-dev';
 import fs from 'fs';
@@ -414,7 +415,17 @@ ipcMain.handle('automate-upload-media', async (event, options) => {
   if (!provider || typeof filePath !== 'string') {
     throw new Error('automate-upload-media requires { provider, filePath }');
   }
-  return automateUploadMedia({ provider, filePath });
+
+  // Automate against a metadata-stripped temp copy when the file is a
+  // strippable image; the user's original file on disk is never modified.
+  const prepared = await prepareStrippedUploadFile(filePath);
+  try {
+    return await automateUploadMedia({ provider, filePath: prepared.filePath });
+  } finally {
+    if (prepared.tempDir) {
+      await fs.promises.rm(prepared.tempDir, { force: true, recursive: true });
+    }
+  }
 });
 
 ipcMain.handle('automate-upload-generated-media', async (event, options) => {

--- a/electron/strip-media-metadata.js
+++ b/electron/strip-media-metadata.js
@@ -5,7 +5,9 @@
  * keep the two byte-level implementations in sync). Removes privacy-sensitive
  * metadata (EXIF/GPS, XMP, IPTC, comments) from JPEG/PNG/WebP before any
  * upload provider sees the bytes. Containers are rewritten losslessly; pixel
- * data is never re-encoded. GIF, video, and unknown formats pass through
+ * data is never re-encoded, so the JPEG Exif Orientation tag (rotation lives
+ * in metadata, not pixels) is re-emitted as a minimal APP1 to keep photos
+ * from rendering sideways. GIF, video, and unknown formats pass through
  * untouched, and on any anomaly the original file is used unchanged so an
  * upload is never blocked.
  */
@@ -20,6 +22,9 @@ const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 /** JPEG segments removed: APP1 (Exif and XMP), APP13 (IPTC/Photoshop), COM. */
 const JPEG_DROPPED_MARKERS = new Set([0xe1, 0xed, 0xfe]);
+
+/** "Exif\0\0" — the payload prefix distinguishing an Exif APP1 from XMP. */
+const EXIF_APP1_HEADER = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00];
 
 /**
  * PNG ancillary chunks kept because they affect rendering (plus APNG frames).
@@ -84,6 +89,7 @@ function stripJpeg(bytes) {
   const len = bytes.length;
   const kept = [bytes.subarray(0, 2)];
   let removedBytes = 0;
+  let orientation = 0;
   let pos = 2;
 
   for (;;) {
@@ -97,7 +103,11 @@ function stripJpeg(bytes) {
     if (marker === 0xda) {
       // SOS: entropy-coded data follows and contains 0xff bytes that are not
       // segment markers, so copy verbatim to EOF instead of parsing. This
-      // also preserves data deliberately appended after EOI.
+      // also preserves data deliberately appended after EOI. Marker segments
+      // after the first SOS are deliberately left untouched: cameras write
+      // metadata before the first scan, and parsing entropy-coded data risks
+      // degrading exotic-but-valid files (e.g. motion-photo trailers) into
+      // full pass-through, which would strip less than this does.
       kept.push(bytes.subarray(pos, len));
       break;
     }
@@ -111,6 +121,9 @@ function stripJpeg(bytes) {
     if (end > len) return null;
 
     if (JPEG_DROPPED_MARKERS.has(marker)) {
+      if (marker === 0xe1 && orientation === 0 && isExifApp1Payload(bytes, markerPos + 3, end)) {
+        orientation = readExifOrientation(bytes, markerPos + 9, end);
+      }
       removedBytes += end - pos;
     } else {
       kept.push(bytes.subarray(pos, end));
@@ -119,7 +132,56 @@ function stripJpeg(bytes) {
   }
 
   if (removedBytes === 0) return null;
+  // Rotation lives in metadata, not pixels: re-emit the Orientation tag (and
+  // nothing else) as a minimal APP1 after SOI so photos don't render sideways.
+  if (orientation >= 2 && orientation <= 8) {
+    kept.splice(1, 0, buildOrientationApp1(orientation));
+  }
   return concat(kept);
+}
+
+function isExifApp1Payload(bytes, start, end) {
+  return start + EXIF_APP1_HEADER.length <= end && EXIF_APP1_HEADER.every((b, i) => bytes[start + i] === b);
+}
+
+/** Reads the Orientation tag (1-8) from IFD0 of an Exif TIFF block, or 0 when absent or malformed. */
+function readExifOrientation(bytes, tiffStart, end) {
+  if (tiffStart + 8 > end) return 0;
+  let little;
+  if (bytes[tiffStart] === 0x49 && bytes[tiffStart + 1] === 0x49) little = true;
+  else if (bytes[tiffStart] === 0x4d && bytes[tiffStart + 1] === 0x4d) little = false;
+  else return 0;
+  const readU16 = (pos) => (little ? bytes[pos] | (bytes[pos + 1] << 8) : (bytes[pos] << 8) | bytes[pos + 1]);
+  const readU32 = (pos) => (little ? readU32le(bytes, pos) : readU32be(bytes, pos));
+  if (readU16(tiffStart + 2) !== 42) return 0;
+  const ifdOffset = readU32(tiffStart + 4);
+  if (ifdOffset < 8) return 0;
+  const ifdPos = tiffStart + ifdOffset;
+  if (ifdPos + 2 > end) return 0;
+  const entryCount = readU16(ifdPos);
+  for (let i = 0; i < entryCount; i++) {
+    const entry = ifdPos + 2 + i * 12;
+    if (entry + 12 > end) return 0;
+    if (readU16(entry) !== 0x0112) continue;
+    // Orientation must be a single SHORT; the value sits in the first two payload bytes.
+    if (readU16(entry + 2) !== 3 || readU32(entry + 4) !== 1) return 0;
+    const value = readU16(entry + 8);
+    return value >= 1 && value <= 8 ? value : 0;
+  }
+  return 0;
+}
+
+/** Minimal little-endian Exif APP1 whose IFD0 holds only the Orientation tag. */
+function buildOrientationApp1(orientation) {
+  // prettier-ignore
+  return new Uint8Array([
+    0xff, 0xe1, 0x00, 0x22, // APP1, length 34
+    0x45, 0x78, 0x69, 0x66, 0x00, 0x00, // "Exif\0\0"
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, // "II", 42, IFD0 at offset 8
+    0x01, 0x00, // one IFD entry
+    0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, orientation, 0x00, 0x00, 0x00, // Orientation, SHORT x1
+    0x00, 0x00, 0x00, 0x00, // no next IFD
+  ]);
 }
 
 function stripPng(bytes) {

--- a/electron/strip-media-metadata.js
+++ b/electron/strip-media-metadata.js
@@ -1,0 +1,230 @@
+/**
+ * Main-process media metadata stripping for the disk-path upload automation
+ * route, where the renderer only hands over a file path and the bytes never
+ * transit JS (parity with src/lib/media-metadata/strip-media-metadata.ts —
+ * keep the two byte-level implementations in sync). Removes privacy-sensitive
+ * metadata (EXIF/GPS, XMP, IPTC, comments) from JPEG/PNG/WebP before any
+ * upload provider sees the bytes. Containers are rewritten losslessly; pixel
+ * data is never re-encoded. GIF, video, and unknown formats pass through
+ * untouched, and on any anomaly the original file is used unchanged so an
+ * upload is never blocked.
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/** Files larger than this pass through untouched to avoid large in-memory copies. */
+const MAX_PROCESSABLE_BYTES = 64 * 1024 * 1024;
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** JPEG segments removed: APP1 (Exif and XMP), APP13 (IPTC/Photoshop), COM. */
+const JPEG_DROPPED_MARKERS = new Set([0xe1, 0xed, 0xfe]);
+
+/**
+ * PNG ancillary chunks kept because they affect rendering (plus APNG frames).
+ * Critical chunks are always kept; ancillary chunks not listed here (tEXt,
+ * zTXt, iTXt, eXIf, tIME, and unknown ones) are dropped.
+ */
+const PNG_KEPT_ANCILLARY_CHUNKS = new Set(['tRNS', 'gAMA', 'cHRM', 'sRGB', 'iCCP', 'sBIT', 'bKGD', 'pHYs', 'acTL', 'fcTL', 'fdAT']);
+
+/** VP8X header flag bits announcing EXIF (0x08) and XMP (0x04) chunks. */
+const WEBP_VP8X_METADATA_FLAGS = 0x0c;
+
+/**
+ * Prepares the file for upload automation: when it is a JPEG/PNG/WebP with
+ * removable metadata, writes a stripped copy (same basename, so the uploaded
+ * filename is unchanged) into a fresh temp dir and returns that path plus the
+ * temp dir the caller must remove afterwards. Returns the original path with a
+ * null tempDir when there is nothing to strip, the format is not handled, the
+ * file is too large, or anything fails — uploads never break, and the user's
+ * original file is never modified.
+ * @param {string} filePath - Absolute path to the file to upload
+ * @returns {Promise<{ filePath: string; tempDir: string | null }>}
+ */
+export async function prepareStrippedUploadFile(filePath) {
+  let tempDir = null;
+  try {
+    const { size } = await fs.promises.stat(filePath);
+    if (size > MAX_PROCESSABLE_BYTES) return { filePath, tempDir: null };
+    const stripped = stripMediaMetadataBytes(await fs.promises.readFile(filePath));
+    if (stripped === null) return { filePath, tempDir: null };
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), '5chan-strip-'));
+    const strippedPath = path.join(tempDir, path.basename(filePath));
+    await fs.promises.writeFile(strippedPath, stripped);
+    return { filePath: strippedPath, tempDir };
+  } catch {
+    if (tempDir) await fs.promises.rm(tempDir, { force: true, recursive: true }).catch(() => {});
+    return { filePath, tempDir: null };
+  }
+}
+
+/**
+ * Detects the format by magic bytes (mime/extension are never trusted) and
+ * returns a stripped copy, or null meaning "keep original". Exported for tests.
+ * @param {Uint8Array} bytes
+ * @returns {Uint8Array | null}
+ */
+export function stripMediaMetadataBytes(bytes) {
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return stripJpeg(bytes);
+  }
+  if (bytes.length >= 8 && PNG_SIGNATURE.every((b, i) => bytes[i] === b)) {
+    return stripPng(bytes);
+  }
+  if (bytes.length >= 16 && readFourCc(bytes, 0) === 'RIFF' && readFourCc(bytes, 8) === 'WEBP') {
+    return stripWebp(bytes);
+  }
+  // GIF passes through deliberately (rewriting animations is risky and GIFs
+  // carry no GPS-class metadata); video and unknown formats pass through too.
+  return null;
+}
+
+function stripJpeg(bytes) {
+  const len = bytes.length;
+  const kept = [bytes.subarray(0, 2)];
+  let removedBytes = 0;
+  let pos = 2;
+
+  for (;;) {
+    if (pos + 1 >= len || bytes[pos] !== 0xff) return null;
+    // A marker may be preceded by any number of 0xff fill bytes.
+    let markerPos = pos + 1;
+    while (markerPos < len && bytes[markerPos] === 0xff) markerPos++;
+    if (markerPos >= len) return null;
+    const marker = bytes[markerPos];
+
+    if (marker === 0xda) {
+      // SOS: entropy-coded data follows and contains 0xff bytes that are not
+      // segment markers, so copy verbatim to EOF instead of parsing. This
+      // also preserves data deliberately appended after EOI.
+      kept.push(bytes.subarray(pos, len));
+      break;
+    }
+    // Standalone markers (TEM, RST, SOI, EOI) are not expected before SOS.
+    if (marker === 0x00 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) return null;
+
+    if (markerPos + 2 >= len) return null;
+    const segmentLength = (bytes[markerPos + 1] << 8) | bytes[markerPos + 2];
+    if (segmentLength < 2) return null;
+    const end = markerPos + 1 + segmentLength;
+    if (end > len) return null;
+
+    if (JPEG_DROPPED_MARKERS.has(marker)) {
+      removedBytes += end - pos;
+    } else {
+      kept.push(bytes.subarray(pos, end));
+    }
+    pos = end;
+  }
+
+  if (removedBytes === 0) return null;
+  return concat(kept);
+}
+
+function stripPng(bytes) {
+  const len = bytes.length;
+  const kept = [bytes.subarray(0, 8)];
+  let removedBytes = 0;
+  let pos = 8;
+
+  for (;;) {
+    if (pos + 8 > len) return null; // ran out of bytes before IEND
+    const dataLength = readU32be(bytes, pos);
+    if (dataLength > 0x7fffffff) return null;
+    const end = pos + 12 + dataLength; // length + type + data + CRC
+    if (end > len) return null;
+    const type = readFourCc(bytes, pos + 4);
+
+    if (type === 'IEND') {
+      // Keep IEND and any deliberately appended trailing data verbatim.
+      kept.push(bytes.subarray(pos, len));
+      break;
+    }
+
+    const isCritical = (bytes[pos + 4] & 0x20) === 0;
+    if (isCritical || PNG_KEPT_ANCILLARY_CHUNKS.has(type)) {
+      // Chunks are copied whole so their CRCs remain valid.
+      kept.push(bytes.subarray(pos, end));
+    } else {
+      removedBytes += end - pos;
+    }
+    pos = end;
+  }
+
+  if (removedBytes === 0) return null;
+  return concat(kept);
+}
+
+function stripWebp(bytes) {
+  const len = bytes.length;
+  const riffEnd = 8 + readU32le(bytes, 4);
+  if (riffEnd < 12 || riffEnd > len) return null;
+
+  const kept = [bytes.subarray(0, 12)];
+  let outLength = 12;
+  let removedBytes = 0;
+  let vp8xFlagsOffset = -1;
+  let vp8xHasMetadataFlags = false;
+  let pos = 12;
+
+  while (pos < riffEnd) {
+    if (pos + 8 > riffEnd) return null;
+    const fourCc = readFourCc(bytes, pos);
+    const chunkSize = readU32le(bytes, pos + 4);
+    const end = pos + 8 + chunkSize + (chunkSize & 1); // chunks are padded to even sizes
+    if (end > riffEnd) return null;
+
+    if (fourCc === 'EXIF' || fourCc === 'XMP ') {
+      removedBytes += end - pos;
+    } else {
+      if (fourCc === 'VP8X') {
+        if (chunkSize < 10) return null;
+        vp8xFlagsOffset = outLength + 8;
+        vp8xHasMetadataFlags = (bytes[pos + 8] & WEBP_VP8X_METADATA_FLAGS) !== 0;
+      }
+      kept.push(bytes.subarray(pos, end));
+      outLength += end - pos;
+    }
+    pos = end;
+  }
+
+  if (removedBytes === 0 && !vp8xHasMetadataFlags) return null;
+
+  if (riffEnd < len) kept.push(bytes.subarray(riffEnd, len)); // keep appended trailing data
+  const out = concat(kept);
+  writeU32le(out, 4, outLength - 8);
+  if (vp8xFlagsOffset >= 0) out[vp8xFlagsOffset] &= ~WEBP_VP8X_METADATA_FLAGS;
+  return out;
+}
+
+function concat(parts) {
+  let total = 0;
+  for (const part of parts) total += part.length;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function readFourCc(bytes, pos) {
+  return String.fromCharCode(bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]);
+}
+
+function readU32be(bytes, pos) {
+  return ((bytes[pos] << 24) | (bytes[pos + 1] << 16) | (bytes[pos + 2] << 8) | bytes[pos + 3]) >>> 0;
+}
+
+function readU32le(bytes, pos) {
+  return (bytes[pos] | (bytes[pos + 1] << 8) | (bytes[pos + 2] << 16) | (bytes[pos + 3] << 24)) >>> 0;
+}
+
+function writeU32le(bytes, pos, value) {
+  bytes[pos] = value & 0xff;
+  bytes[pos + 1] = (value >>> 8) & 0xff;
+  bytes[pos + 2] = (value >>> 16) & 0xff;
+  bytes[pos + 3] = (value >>> 24) & 0xff;
+}

--- a/electron/strip-media-metadata.test.js
+++ b/electron/strip-media-metadata.test.js
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for strip-media-metadata (Electron main process). The byte-level
+ * fixtures mirror src/lib/media-metadata/__tests__/strip-media-metadata.test.ts
+ * so the renderer and main-process implementations stay in lockstep.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { prepareStrippedUploadFile, stripMediaMetadataBytes } from './strip-media-metadata.js';
+
+function ascii(text) {
+  return Array.from(text, (char) => char.charCodeAt(0));
+}
+
+function u32be(value) {
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff];
+}
+
+function u32le(value) {
+  return [value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff];
+}
+
+function strip(bytes) {
+  const result = stripMediaMetadataBytes(new Uint8Array(bytes));
+  return result === null ? null : Array.from(result);
+}
+
+// --- JPEG fixtures ---
+
+function jpegSegment(marker, payload) {
+  const length = payload.length + 2;
+  return [0xff, marker, (length >> 8) & 0xff, length & 0xff, ...payload];
+}
+
+const SOI = [0xff, 0xd8];
+const app0Jfif = jpegSegment(0xe0, [...ascii('JFIF'), 0, 1, 1, 0, 0, 1, 0, 1, 0, 0]);
+const app1Exif = jpegSegment(0xe1, [...ascii('Exif'), 0, 0, ...ascii('II*'), 0, ...ascii('GPSLATITUDE 51.5072')]);
+const app1Xmp = jpegSegment(0xe1, [...ascii('http://ns.adobe.com/xap/1.0/'), 0, ...ascii('<x:xmpmeta/>')]);
+const app13Iptc = jpegSegment(0xed, [...ascii('Photoshop 3.0'), 0, ...ascii('8BIM')]);
+const app2Icc = jpegSegment(0xe2, [...ascii('ICC_PROFILE'), 0, 1, 1, 9, 9, 9]);
+const com = jpegSegment(0xfe, ascii('shot on my phone'));
+const dqt = jpegSegment(0xdb, [0, ...Array.from({ length: 64 }, () => 7)]);
+const sof0 = jpegSegment(0xc0, [8, 0, 1, 0, 1, 1, 0x11, 0x11, 0]);
+const dht = jpegSegment(0xc4, [0, ...Array.from({ length: 16 }, () => 0), 0x0a]);
+// SOS header, entropy-coded data with 0xff00 stuffing, EOI, deliberately appended payload
+const sosToEof = [0xff, 0xda, 0x00, 0x08, 1, 1, 0, 0, 63, 0, 0x12, 0xff, 0x00, 0x34, 0xab, 0xff, 0xd9, ...ascii('APPENDED_PAYLOAD')];
+
+const jpegWithMetadata = [...SOI, ...app0Jfif, ...app1Exif, ...app1Xmp, ...app13Iptc, ...app2Icc, ...com, ...dqt, ...sof0, ...dht, ...sosToEof];
+const jpegStripped = [...SOI, ...app0Jfif, ...app2Icc, ...dqt, ...sof0, ...dht, ...sosToEof];
+
+// --- PNG fixtures ---
+
+function crc32(bytes) {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type, data) {
+  const typeBytes = ascii(type);
+  return [...u32be(data.length), ...typeBytes, ...data, ...u32be(crc32([...typeBytes, ...data]))];
+}
+
+const pngSignature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const ihdr = pngChunk('IHDR', [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]);
+const text = pngChunk('tEXt', [...ascii('Comment'), 0, ...ascii('gps: 51.5, -0.1')]);
+const ztxt = pngChunk('zTXt', [...ascii('Author'), 0, 0, 1, 2, 3]);
+const itxt = pngChunk('iTXt', [...ascii('XML:com.adobe.xmp'), 0, 0, 0, 0, 0, ...ascii('<xmp/>')]);
+const exifChunk = pngChunk('eXIf', [...ascii('II*'), 0, 1, 2, 3]);
+const time = pngChunk('tIME', [7, 0xe8, 1, 1, 0, 0, 0]);
+const unknownAncillary = pngChunk('prVt', ascii('secret'));
+const phys = pngChunk('pHYs', [...u32be(2835), ...u32be(2835), 1]);
+const idat = pngChunk('IDAT', [0x78, 0x9c, 1, 2, 3, 4]);
+const iend = pngChunk('IEND', []);
+const pngTrailer = ascii('TRAILING_DATA');
+
+const pngWithMetadata = [...pngSignature, ...ihdr, ...text, ...ztxt, ...itxt, ...exifChunk, ...time, ...unknownAncillary, ...phys, ...idat, ...iend, ...pngTrailer];
+const pngStripped = [...pngSignature, ...ihdr, ...phys, ...idat, ...iend, ...pngTrailer];
+
+// --- WebP fixtures ---
+
+function webpChunk(fourCc, data) {
+  const padded = data.length % 2 === 1 ? [...data, 0] : data;
+  return [...ascii(fourCc), ...u32le(data.length), ...padded];
+}
+
+function riffWebp(chunks) {
+  const payload = chunks.flat();
+  return [...ascii('RIFF'), ...u32le(4 + payload.length), ...ascii('WEBP'), ...payload];
+}
+
+// flags: ALPHA (0x10) | EXIF (0x08) | XMP (0x04)
+const vp8x = webpChunk('VP8X', [0x1c, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+const vp8xCleared = webpChunk('VP8X', [0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+const iccp = webpChunk('ICCP', [1, 2, 3, 4, 5]); // odd size exercises padding
+const webpExif = webpChunk('EXIF', [...ascii('II*'), 0, 0x99]); // odd size exercises padding
+const webpXmp = webpChunk('XMP ', ascii('<x:xmpmeta/>'));
+const vp8 = webpChunk('VP8 ', [0x30, 1, 0, 0x9d, 0x01, 0x2a, 1, 0, 1, 0]);
+
+const webpWithMetadata = riffWebp([vp8x, iccp, webpExif, webpXmp, vp8]);
+const webpStripped = riffWebp([vp8xCleared, iccp, vp8]);
+
+describe('stripMediaMetadataBytes', () => {
+  describe('jpeg', () => {
+    it('removes APP1 (Exif and XMP), APP13, and COM while keeping APP0, APP2, and coding segments', () => {
+      expect(strip(jpegWithMetadata)).toEqual(jpegStripped);
+    });
+
+    it('copies SOS-onward bytes verbatim, including data appended after EOI', () => {
+      const output = strip(jpegWithMetadata);
+
+      expect(output.slice(output.length - sosToEof.length)).toEqual(sosToEof);
+      const appended = ascii('APPENDED_PAYLOAD');
+      expect(output.slice(output.length - appended.length)).toEqual(appended);
+    });
+
+    it('returns null when there is no metadata to remove', () => {
+      expect(strip([...SOI, ...app0Jfif, ...dqt, ...sof0, ...dht, ...sosToEof])).toBeNull();
+    });
+
+    it('returns null when a segment length overruns the file', () => {
+      expect(strip([...SOI, 0xff, 0xe1, 0xff, 0xff, 1, 2, 3])).toBeNull();
+    });
+
+    it('returns null when SOS is never reached', () => {
+      expect(strip([...SOI, ...app1Exif, ...dqt])).toBeNull();
+    });
+
+    it('returns null when marker structure is invalid', () => {
+      expect(strip([...SOI, 0x00, 0x01, 0x02, 0x03])).toBeNull();
+    });
+  });
+
+  describe('png', () => {
+    it('removes tEXt, zTXt, iTXt, eXIf, tIME, and unknown ancillary chunks while keeping listed chunks', () => {
+      expect(strip(pngWithMetadata)).toEqual(pngStripped);
+    });
+
+    it('keeps critical chunks and data appended after IEND', () => {
+      const output = strip(pngWithMetadata);
+
+      expect(output.slice(0, 8)).toEqual(pngSignature);
+      for (const chunk of [ihdr, idat, iend]) {
+        expect(indexOfSequence(output, chunk)).toBeGreaterThanOrEqual(0);
+      }
+      expect(output.slice(output.length - pngTrailer.length)).toEqual(pngTrailer);
+    });
+
+    it('returns null when there is no metadata to remove', () => {
+      expect(strip([...pngSignature, ...ihdr, ...idat, ...iend])).toBeNull();
+    });
+
+    it('returns null when a chunk length overruns the file', () => {
+      expect(strip([...pngSignature, ...u32be(9999), ...ascii('tEXt'), 1, 2, 3])).toBeNull();
+    });
+
+    it('returns null when IEND is missing', () => {
+      expect(strip([...pngSignature, ...ihdr, ...text, ...idat])).toBeNull();
+    });
+  });
+
+  describe('webp', () => {
+    it('removes EXIF and XMP chunks, clears VP8X metadata flags, and fixes the RIFF size', () => {
+      expect(strip(webpWithMetadata)).toEqual(webpStripped);
+    });
+
+    it('clears VP8X metadata flags even when no EXIF or XMP chunk is present', () => {
+      expect(strip(riffWebp([vp8x, vp8]))).toEqual(riffWebp([vp8xCleared, vp8]));
+    });
+
+    it('returns null when there is no metadata to remove', () => {
+      expect(strip(riffWebp([vp8]))).toBeNull();
+    });
+
+    it('returns null when the RIFF size overruns the file', () => {
+      expect(strip([...ascii('RIFF'), ...u32le(9999), ...ascii('WEBP'), ...vp8])).toBeNull();
+    });
+
+    it('returns null when a chunk overruns the RIFF payload', () => {
+      expect(strip(riffWebp([webpChunk('EXIF', [1, 2]).slice(0, 8)]))).toBeNull();
+    });
+  });
+
+  describe('pass-through formats', () => {
+    it('returns null for GIF files, including comment extensions', () => {
+      expect(strip([...ascii('GIF89a'), 1, 0, 1, 0, 0x91, 0, 0, 0x21, 0xfe, 4, ...ascii('gps!'), 0, 0x3b])).toBeNull();
+    });
+
+    it('returns null for mp4 files', () => {
+      expect(strip([...u32be(0x18), ...ascii('ftypmp42'), ...Array.from({ length: 16 }, () => 0)])).toBeNull();
+    });
+
+    it('returns null for webm files', () => {
+      expect(strip([0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4])).toBeNull();
+    });
+
+    it('returns null for unknown formats', () => {
+      expect(strip(ascii('not an image at all'))).toBeNull();
+    });
+
+    it('returns null for empty input', () => {
+      expect(strip([])).toBeNull();
+    });
+  });
+});
+
+describe('prepareStrippedUploadFile', () => {
+  const cleanupDirs = [];
+
+  const makeTestDir = async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), '5chan-strip-test-'));
+    cleanupDirs.push(dir);
+    return dir;
+  };
+
+  const writeTestFile = async (name, bytes) => {
+    const filePath = path.join(await makeTestDir(), name);
+    await fs.promises.writeFile(filePath, new Uint8Array(bytes));
+    return filePath;
+  };
+
+  afterEach(async () => {
+    while (cleanupDirs.length > 0) {
+      await fs.promises.rm(cleanupDirs.pop(), { force: true, recursive: true });
+    }
+  });
+
+  it('writes a stripped copy with the same basename to a temp dir and leaves the original untouched', async () => {
+    const filePath = await writeTestFile('photo.jpg', jpegWithMetadata);
+
+    const prepared = await prepareStrippedUploadFile(filePath);
+    if (prepared.tempDir) cleanupDirs.push(prepared.tempDir);
+
+    expect(prepared.tempDir).not.toBeNull();
+    expect(prepared.filePath).not.toBe(filePath);
+    expect(path.basename(prepared.filePath)).toBe('photo.jpg');
+    expect(Array.from(await fs.promises.readFile(prepared.filePath))).toEqual(jpegStripped);
+    expect(Array.from(await fs.promises.readFile(filePath))).toEqual(jpegWithMetadata);
+  });
+
+  it('returns the original path when there is no metadata to remove', async () => {
+    const filePath = await writeTestFile('clean.jpg', [...SOI, ...app0Jfif, ...dqt, ...sof0, ...dht, ...sosToEof]);
+
+    expect(await prepareStrippedUploadFile(filePath)).toEqual({ filePath, tempDir: null });
+  });
+
+  it('returns the original path for pass-through formats', async () => {
+    const filePath = await writeTestFile('anim.gif', [...ascii('GIF89a'), 1, 0, 1, 0, 0x91, 0, 0, 0x3b]);
+
+    expect(await prepareStrippedUploadFile(filePath)).toEqual({ filePath, tempDir: null });
+  });
+
+  it('returns the original path for files over the size cap without reading them', async () => {
+    const filePath = path.join(await makeTestDir(), 'huge.jpg');
+    const handle = await fs.promises.open(filePath, 'w');
+    await handle.truncate(64 * 1024 * 1024 + 1); // sparse file: instant to create, slow to read
+    await handle.close();
+
+    expect(await prepareStrippedUploadFile(filePath)).toEqual({ filePath, tempDir: null });
+  });
+
+  it('returns the original path when the file cannot be read', async () => {
+    const filePath = path.join(await makeTestDir(), 'missing.jpg');
+
+    expect(await prepareStrippedUploadFile(filePath)).toEqual({ filePath, tempDir: null });
+  });
+});
+
+function indexOfSequence(haystack, needle) {
+  outer: for (let i = 0; i + needle.length <= haystack.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}

--- a/electron/strip-media-metadata.test.js
+++ b/electron/strip-media-metadata.test.js
@@ -49,6 +49,94 @@ const sosToEof = [0xff, 0xda, 0x00, 0x08, 1, 1, 0, 0, 63, 0, 0x12, 0xff, 0x00, 0
 const jpegWithMetadata = [...SOI, ...app0Jfif, ...app1Exif, ...app1Xmp, ...app13Iptc, ...app2Icc, ...com, ...dqt, ...sof0, ...dht, ...sosToEof];
 const jpegStripped = [...SOI, ...app0Jfif, ...app2Icc, ...dqt, ...sof0, ...dht, ...sosToEof];
 
+/** Valid Exif APP1 whose IFD0 holds a Make entry (exercises the walk) and an Orientation entry. */
+function exifApp1WithOrientation(orientation, littleEndian = true) {
+  const tiff = littleEndian
+    ? [
+        0x49,
+        0x49,
+        0x2a,
+        0x00,
+        ...u32le(8), // "II", 42, IFD0 at offset 8
+        0x02,
+        0x00, // two entries
+        0x0f,
+        0x01,
+        0x02,
+        0x00,
+        ...u32le(4),
+        ...ascii('abc'),
+        0x00, // Make, ASCII x4 inline
+        0x12,
+        0x01,
+        0x03,
+        0x00,
+        ...u32le(1),
+        orientation,
+        0x00,
+        0x00,
+        0x00, // Orientation, SHORT x1
+        ...u32le(0), // no next IFD
+      ]
+    : [
+        0x4d,
+        0x4d,
+        0x00,
+        0x2a,
+        ...u32be(8), // "MM", 42, IFD0 at offset 8
+        0x00,
+        0x02,
+        0x01,
+        0x0f,
+        0x00,
+        0x02,
+        ...u32be(4),
+        ...ascii('abc'),
+        0x00,
+        0x01,
+        0x12,
+        0x00,
+        0x03,
+        ...u32be(1),
+        0x00,
+        orientation,
+        0x00,
+        0x00,
+        ...u32be(0),
+      ];
+  return jpegSegment(0xe1, [...ascii('Exif'), 0, 0, ...tiff]);
+}
+
+/** The minimal APP1 the stripper is expected to synthesize (always little-endian). */
+function orientationApp1(orientation) {
+  return [
+    0xff,
+    0xe1,
+    0x00,
+    0x22,
+    ...ascii('Exif'),
+    0,
+    0,
+    0x49,
+    0x49,
+    0x2a,
+    0x00,
+    ...u32le(8),
+    0x01,
+    0x00,
+    0x12,
+    0x01,
+    0x03,
+    0x00,
+    ...u32le(1),
+    orientation,
+    0x00,
+    0x00,
+    0x00,
+    ...u32le(0),
+  ];
+}
+
 // --- PNG fixtures ---
 
 function crc32(bytes) {
@@ -134,6 +222,37 @@ describe('stripMediaMetadataBytes', () => {
 
     it('returns null when marker structure is invalid', () => {
       expect(strip([...SOI, 0x00, 0x01, 0x02, 0x03])).toBeNull();
+    });
+
+    it('re-emits the Exif Orientation tag as a minimal APP1 so photos keep their rotation', () => {
+      expect(strip([...SOI, ...app0Jfif, ...exifApp1WithOrientation(6), ...com, ...dqt, ...sof0, ...dht, ...sosToEof])).toEqual([
+        ...SOI,
+        ...orientationApp1(6),
+        ...app0Jfif,
+        ...dqt,
+        ...sof0,
+        ...dht,
+        ...sosToEof,
+      ]);
+    });
+
+    it('reads big-endian Exif and re-emits the orientation little-endian', () => {
+      expect(strip([...SOI, ...exifApp1WithOrientation(3, false), ...dqt, ...sof0, ...dht, ...sosToEof])).toEqual([
+        ...SOI,
+        ...orientationApp1(3),
+        ...dqt,
+        ...sof0,
+        ...dht,
+        ...sosToEof,
+      ]);
+    });
+
+    it('does not re-emit the default orientation 1', () => {
+      expect(strip([...SOI, ...exifApp1WithOrientation(1), ...dqt, ...sof0, ...dht, ...sosToEof])).toEqual([...SOI, ...dqt, ...sof0, ...dht, ...sosToEof]);
+    });
+
+    it('does not re-emit an out-of-range orientation value', () => {
+      expect(strip([...SOI, ...exifApp1WithOrientation(9), ...dqt, ...sof0, ...dht, ...sosToEof])).toEqual([...SOI, ...dqt, ...sof0, ...dht, ...sosToEof]);
     });
   });
 

--- a/src/hooks/use-file-upload.ts
+++ b/src/hooks/use-file-upload.ts
@@ -5,6 +5,7 @@ import { formatAggregatedError, formatPreferredModeError, type ProviderAttempt }
 import { getProviderOrder } from '../lib/media-hosting/provider-order';
 import { getMediaHostingRuntime, isElectronRuntime } from '../lib/media-hosting/show-upload-controls';
 import { orchestrateElectronUpload } from '../lib/media-hosting/upload-orchestrator';
+import { stripMediaMetadata } from '../lib/media-metadata/strip-media-metadata';
 import { ensureProviderAvailability } from '../lib/media-hosting/provider-availability';
 import useMediaHostingStore from '../stores/use-media-hosting-store';
 import type { ProviderId, UploadAttemptStage } from '../lib/media-hosting/types';
@@ -225,11 +226,12 @@ export function useFileUpload(options: UseFileUploadOptions) {
         let result: UploadedFileResult | null = null;
 
         if (runtime === 'android') {
+          const cleanFile = await stripMediaMetadata(file);
           const pluginResult = await FileUploader.uploadGeneratedMedia({
             providerOrder: order,
-            fileName: file.name,
-            mimeType: file.type || 'application/octet-stream',
-            base64: await readFileAsBase64(file),
+            fileName: cleanFile.name,
+            mimeType: cleanFile.type || 'application/octet-stream',
+            base64: await readFileAsBase64(cleanFile),
           });
           result = pluginResult.url ? { url: pluginResult.url, fileName: pluginResult.fileName || file.name } : null;
         } else if (runtime === 'electron') {
@@ -262,6 +264,8 @@ export function useFileUpload(options: UseFileUploadOptions) {
       setUploadedFileName(null);
       const { runtime, order } = await getAvailableProviderOrder();
       if (runtime === 'android') {
+        // Known gap: the native picker uploads straight from the device, so
+        // metadata stripping for this route needs plugin-side support.
         const result = await FileUploader.pickAndUploadMedia({ providerOrder: order });
         if (result.url) {
           if (result.fileName) setUploadedFileName(result.fileName);

--- a/src/hooks/use-file-upload.ts
+++ b/src/hooks/use-file-upload.ts
@@ -264,8 +264,8 @@ export function useFileUpload(options: UseFileUploadOptions) {
       setUploadedFileName(null);
       const { runtime, order } = await getAvailableProviderOrder();
       if (runtime === 'android') {
-        // Known gap: the native picker uploads straight from the device, so
-        // metadata stripping for this route needs plugin-side support.
+        // The native picker uploads straight from the device; the plugin strips
+        // metadata before upload (android MediaMetadataStripper).
         const result = await FileUploader.pickAndUploadMedia({ providerOrder: order });
         if (result.url) {
           if (result.fileName) setUploadedFileName(result.fileName);

--- a/src/lib/media-hosting/__tests__/upload-orchestrator.test.ts
+++ b/src/lib/media-hosting/__tests__/upload-orchestrator.test.ts
@@ -7,6 +7,10 @@ vi.mock('../../utils/catbox-utils', () => ({
   uploadToCatbox: vi.fn(),
 }));
 
+// Minimal JPEG: SOI + COM segment ("gps!") + SOS with entropy data.
+const jpegWithComment = [0xff, 0xd8, 0xff, 0xfe, 0x00, 0x06, 0x67, 0x70, 0x73, 0x21, 0xff, 0xda, 0x00, 0x02, 0x11, 0x22];
+const jpegWithoutComment = [0xff, 0xd8, 0xff, 0xda, 0x00, 0x02, 0x11, 0x22];
+
 function createElectronApiMock() {
   return {
     isElectron: true,
@@ -33,6 +37,34 @@ describe('orchestrateElectronUpload', () => {
 
     expect(url).toBe('https://files.catbox.moe/a.png');
     expect(uploadToCatbox).toHaveBeenCalledWith(file);
+  });
+
+  it('strips image metadata before uploading to catbox', async () => {
+    vi.mocked(uploadToCatbox).mockResolvedValue('https://files.catbox.moe/b.jpg');
+    const file = new File([new Uint8Array(jpegWithComment)], 'photo.jpg', { type: 'image/jpeg' });
+
+    await orchestrateElectronUpload(file, ['catbox']);
+
+    const uploaded = vi.mocked(uploadToCatbox).mock.calls[0][0];
+    expect(uploaded).not.toBe(file);
+    expect(uploaded.name).toBe('photo.jpg');
+    expect(Array.from(new Uint8Array(await uploaded.arrayBuffer()))).toEqual(jpegWithoutComment);
+  });
+
+  it('strips image metadata before generated media automation', async () => {
+    const electronApi = createElectronApiMock();
+    electronApi.getPathForFile = vi.fn((): string | null => null);
+    window.electronApi = electronApi;
+
+    const file = new File([new Uint8Array(jpegWithComment)], 'photo.jpg', { type: 'image/jpeg' });
+    await orchestrateElectronUpload(file, ['imgur']);
+
+    expect(electronApi.automateUploadGeneratedMedia).toHaveBeenCalledWith({
+      provider: 'imgur',
+      fileName: 'photo.jpg',
+      mimeType: 'image/jpeg',
+      bytes: jpegWithoutComment,
+    });
   });
 
   it('uses electronApi.getPathForFile when File.path is unavailable', async () => {

--- a/src/lib/media-hosting/upload-orchestrator.ts
+++ b/src/lib/media-hosting/upload-orchestrator.ts
@@ -1,4 +1,5 @@
 import type { ProviderAttempt, ProviderId, UploadAttemptStage } from './types';
+import { stripMediaMetadata } from '../media-metadata/strip-media-metadata';
 import { uploadToCatbox } from '../utils/catbox-utils';
 
 /** Attempt metadata inferred or parsed from plugin rejection. Used when plugins throw plain errors. */
@@ -65,12 +66,14 @@ async function fileToByteArray(file: File): Promise<number[]> {
  * imgur/imgbb use Electron automation when available.
  */
 async function uploadViaProvider(provider: ProviderId, file: File): Promise<string> {
-  if (provider === 'catbox') return uploadToCatbox(file);
+  if (provider === 'catbox') return uploadToCatbox(await stripMediaMetadata(file));
   if (provider === 'imgur' || provider === 'imgbb') {
     const fn = typeof window !== 'undefined' && window.electronApi?.automateUploadMedia;
     if (fn) {
       const filePath = resolveElectronFilePath(file);
       if (filePath) {
+        // Known gap: disk-path automation uploads the file as-is; metadata
+        // stripping for this route needs native-side support.
         const { url } = await fn({ provider, filePath });
         return url;
       }
@@ -79,11 +82,12 @@ async function uploadViaProvider(provider: ProviderId, file: File): Promise<stri
       if (!generatedFn) {
         throw new Error('File path unavailable and automateUploadGeneratedMedia is not available');
       }
+      const cleanFile = await stripMediaMetadata(file);
       const { url } = await generatedFn({
         provider,
-        fileName: file.name,
-        mimeType: file.type || 'application/octet-stream',
-        bytes: await fileToByteArray(file),
+        fileName: cleanFile.name,
+        mimeType: cleanFile.type || 'application/octet-stream',
+        bytes: await fileToByteArray(cleanFile),
       });
       return url;
     }

--- a/src/lib/media-hosting/upload-orchestrator.ts
+++ b/src/lib/media-hosting/upload-orchestrator.ts
@@ -72,8 +72,8 @@ async function uploadViaProvider(provider: ProviderId, file: File): Promise<stri
     if (fn) {
       const filePath = resolveElectronFilePath(file);
       if (filePath) {
-        // Known gap: disk-path automation uploads the file as-is; metadata
-        // stripping for this route needs native-side support.
+        // Bytes for this route never transit JS; the Electron main process
+        // strips metadata before automation (electron/strip-media-metadata.js).
         const { url } = await fn({ provider, filePath });
         return url;
       }

--- a/src/lib/media-metadata/__tests__/strip-media-metadata.test.ts
+++ b/src/lib/media-metadata/__tests__/strip-media-metadata.test.ts
@@ -44,6 +44,94 @@ const sosToEof = [0xff, 0xda, 0x00, 0x08, 1, 1, 0, 0, 63, 0, 0x12, 0xff, 0x00, 0
 const jpegWithMetadata = [...SOI, ...app0Jfif, ...app1Exif, ...app1Xmp, ...app13Iptc, ...app2Icc, ...com, ...dqt, ...sof0, ...dht, ...sosToEof];
 const jpegStripped = [...SOI, ...app0Jfif, ...app2Icc, ...dqt, ...sof0, ...dht, ...sosToEof];
 
+/** Valid Exif APP1 whose IFD0 holds a Make entry (exercises the walk) and an Orientation entry. */
+function exifApp1WithOrientation(orientation: number, littleEndian = true): number[] {
+  const tiff = littleEndian
+    ? [
+        0x49,
+        0x49,
+        0x2a,
+        0x00,
+        ...u32le(8), // "II", 42, IFD0 at offset 8
+        0x02,
+        0x00, // two entries
+        0x0f,
+        0x01,
+        0x02,
+        0x00,
+        ...u32le(4),
+        ...ascii('abc'),
+        0x00, // Make, ASCII x4 inline
+        0x12,
+        0x01,
+        0x03,
+        0x00,
+        ...u32le(1),
+        orientation,
+        0x00,
+        0x00,
+        0x00, // Orientation, SHORT x1
+        ...u32le(0), // no next IFD
+      ]
+    : [
+        0x4d,
+        0x4d,
+        0x00,
+        0x2a,
+        ...u32be(8), // "MM", 42, IFD0 at offset 8
+        0x00,
+        0x02,
+        0x01,
+        0x0f,
+        0x00,
+        0x02,
+        ...u32be(4),
+        ...ascii('abc'),
+        0x00,
+        0x01,
+        0x12,
+        0x00,
+        0x03,
+        ...u32be(1),
+        0x00,
+        orientation,
+        0x00,
+        0x00,
+        ...u32be(0),
+      ];
+  return jpegSegment(0xe1, [...ascii('Exif'), 0, 0, ...tiff]);
+}
+
+/** The minimal APP1 the stripper is expected to synthesize (always little-endian). */
+function orientationApp1(orientation: number): number[] {
+  return [
+    0xff,
+    0xe1,
+    0x00,
+    0x22,
+    ...ascii('Exif'),
+    0,
+    0,
+    0x49,
+    0x49,
+    0x2a,
+    0x00,
+    ...u32le(8),
+    0x01,
+    0x00,
+    0x12,
+    0x01,
+    0x03,
+    0x00,
+    ...u32le(1),
+    orientation,
+    0x00,
+    0x00,
+    0x00,
+    ...u32le(0),
+  ];
+}
+
 // --- PNG fixtures ---
 
 function crc32(bytes: number[]): number {
@@ -152,6 +240,30 @@ describe('stripMediaMetadata', () => {
       const file = makeFile([...SOI, 0x00, 0x01, 0x02, 0x03], 'garbage.jpg', 'image/jpeg');
 
       expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('re-emits the Exif Orientation tag as a minimal APP1 so photos keep their rotation', async () => {
+      const file = makeFile([...SOI, ...app0Jfif, ...exifApp1WithOrientation(6), ...com, ...dqt, ...sof0, ...dht, ...sosToEof], 'portrait.jpg', 'image/jpeg');
+
+      expect(await bytesOf(await stripMediaMetadata(file))).toEqual([...SOI, ...orientationApp1(6), ...app0Jfif, ...dqt, ...sof0, ...dht, ...sosToEof]);
+    });
+
+    it('reads big-endian Exif and re-emits the orientation little-endian', async () => {
+      const file = makeFile([...SOI, ...exifApp1WithOrientation(3, false), ...dqt, ...sof0, ...dht, ...sosToEof], 'be.jpg', 'image/jpeg');
+
+      expect(await bytesOf(await stripMediaMetadata(file))).toEqual([...SOI, ...orientationApp1(3), ...dqt, ...sof0, ...dht, ...sosToEof]);
+    });
+
+    it('does not re-emit the default orientation 1', async () => {
+      const file = makeFile([...SOI, ...exifApp1WithOrientation(1), ...dqt, ...sof0, ...dht, ...sosToEof], 'upright.jpg', 'image/jpeg');
+
+      expect(await bytesOf(await stripMediaMetadata(file))).toEqual([...SOI, ...dqt, ...sof0, ...dht, ...sosToEof]);
+    });
+
+    it('does not re-emit an out-of-range orientation value', async () => {
+      const file = makeFile([...SOI, ...exifApp1WithOrientation(9), ...dqt, ...sof0, ...dht, ...sosToEof], 'invalid.jpg', 'image/jpeg');
+
+      expect(await bytesOf(await stripMediaMetadata(file))).toEqual([...SOI, ...dqt, ...sof0, ...dht, ...sosToEof]);
     });
   });
 

--- a/src/lib/media-metadata/__tests__/strip-media-metadata.test.ts
+++ b/src/lib/media-metadata/__tests__/strip-media-metadata.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+import { stripMediaMetadata } from '../strip-media-metadata';
+
+function ascii(text: string): number[] {
+  return Array.from(text, (char) => char.charCodeAt(0));
+}
+
+function u32be(value: number): number[] {
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff];
+}
+
+function u32le(value: number): number[] {
+  return [value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff];
+}
+
+function makeFile(bytes: number[], name: string, type: string): File {
+  return new File([new Uint8Array(bytes)], name, { type, lastModified: 1700000000000 });
+}
+
+async function bytesOf(file: File): Promise<number[]> {
+  return Array.from(new Uint8Array(await file.arrayBuffer()));
+}
+
+// --- JPEG fixtures ---
+
+function jpegSegment(marker: number, payload: number[]): number[] {
+  const length = payload.length + 2;
+  return [0xff, marker, (length >> 8) & 0xff, length & 0xff, ...payload];
+}
+
+const SOI = [0xff, 0xd8];
+const app0Jfif = jpegSegment(0xe0, [...ascii('JFIF'), 0, 1, 1, 0, 0, 1, 0, 1, 0, 0]);
+const app1Exif = jpegSegment(0xe1, [...ascii('Exif'), 0, 0, ...ascii('II*'), 0, ...ascii('GPSLATITUDE 51.5072')]);
+const app1Xmp = jpegSegment(0xe1, [...ascii('http://ns.adobe.com/xap/1.0/'), 0, ...ascii('<x:xmpmeta/>')]);
+const app13Iptc = jpegSegment(0xed, [...ascii('Photoshop 3.0'), 0, ...ascii('8BIM')]);
+const app2Icc = jpegSegment(0xe2, [...ascii('ICC_PROFILE'), 0, 1, 1, 9, 9, 9]);
+const com = jpegSegment(0xfe, ascii('shot on my phone'));
+const dqt = jpegSegment(0xdb, [0, ...Array.from({ length: 64 }, () => 7)]);
+const sof0 = jpegSegment(0xc0, [8, 0, 1, 0, 1, 1, 0x11, 0x11, 0]);
+const dht = jpegSegment(0xc4, [0, ...Array.from({ length: 16 }, () => 0), 0x0a]);
+// SOS header, entropy-coded data with 0xff00 stuffing, EOI, deliberately appended payload
+const sosToEof = [0xff, 0xda, 0x00, 0x08, 1, 1, 0, 0, 63, 0, 0x12, 0xff, 0x00, 0x34, 0xab, 0xff, 0xd9, ...ascii('APPENDED_PAYLOAD')];
+
+const jpegWithMetadata = [...SOI, ...app0Jfif, ...app1Exif, ...app1Xmp, ...app13Iptc, ...app2Icc, ...com, ...dqt, ...sof0, ...dht, ...sosToEof];
+const jpegStripped = [...SOI, ...app0Jfif, ...app2Icc, ...dqt, ...sof0, ...dht, ...sosToEof];
+
+// --- PNG fixtures ---
+
+function crc32(bytes: number[]): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: number[]): number[] {
+  const typeBytes = ascii(type);
+  return [...u32be(data.length), ...typeBytes, ...data, ...u32be(crc32([...typeBytes, ...data]))];
+}
+
+const pngSignature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const ihdr = pngChunk('IHDR', [...u32be(1), ...u32be(1), 8, 6, 0, 0, 0]);
+const text = pngChunk('tEXt', [...ascii('Comment'), 0, ...ascii('gps: 51.5, -0.1')]);
+const ztxt = pngChunk('zTXt', [...ascii('Author'), 0, 0, 1, 2, 3]);
+const itxt = pngChunk('iTXt', [...ascii('XML:com.adobe.xmp'), 0, 0, 0, 0, 0, ...ascii('<xmp/>')]);
+const exifChunk = pngChunk('eXIf', [...ascii('II*'), 0, 1, 2, 3]);
+const time = pngChunk('tIME', [7, 0xe8, 1, 1, 0, 0, 0]);
+const unknownAncillary = pngChunk('prVt', ascii('secret'));
+const phys = pngChunk('pHYs', [...u32be(2835), ...u32be(2835), 1]);
+const idat = pngChunk('IDAT', [0x78, 0x9c, 1, 2, 3, 4]);
+const iend = pngChunk('IEND', []);
+const pngTrailer = ascii('TRAILING_DATA');
+
+const pngWithMetadata = [...pngSignature, ...ihdr, ...text, ...ztxt, ...itxt, ...exifChunk, ...time, ...unknownAncillary, ...phys, ...idat, ...iend, ...pngTrailer];
+const pngStripped = [...pngSignature, ...ihdr, ...phys, ...idat, ...iend, ...pngTrailer];
+
+// --- WebP fixtures ---
+
+function webpChunk(fourCc: string, data: number[]): number[] {
+  const padded = data.length % 2 === 1 ? [...data, 0] : data;
+  return [...ascii(fourCc), ...u32le(data.length), ...padded];
+}
+
+function riffWebp(chunks: number[][]): number[] {
+  const payload = chunks.flat();
+  return [...ascii('RIFF'), ...u32le(4 + payload.length), ...ascii('WEBP'), ...payload];
+}
+
+// flags: ALPHA (0x10) | EXIF (0x08) | XMP (0x04)
+const vp8x = webpChunk('VP8X', [0x1c, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+const vp8xCleared = webpChunk('VP8X', [0x10, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+const iccp = webpChunk('ICCP', [1, 2, 3, 4, 5]); // odd size exercises padding
+const webpExif = webpChunk('EXIF', [...ascii('II*'), 0, 0x99]); // odd size exercises padding
+const webpXmp = webpChunk('XMP ', ascii('<x:xmpmeta/>'));
+const vp8 = webpChunk('VP8 ', [0x30, 1, 0, 0x9d, 0x01, 0x2a, 1, 0, 1, 0]);
+
+const webpWithMetadata = riffWebp([vp8x, iccp, webpExif, webpXmp, vp8]);
+const webpStripped = riffWebp([vp8xCleared, iccp, vp8]);
+
+describe('stripMediaMetadata', () => {
+  describe('jpeg', () => {
+    it('removes APP1 (Exif and XMP), APP13, and COM while keeping APP0, APP2, and coding segments', async () => {
+      const file = makeFile(jpegWithMetadata, 'photo.jpg', 'image/jpeg');
+      const result = await stripMediaMetadata(file);
+
+      expect(result).not.toBe(file);
+      expect(await bytesOf(result)).toEqual(jpegStripped);
+    });
+
+    it('copies SOS-onward bytes verbatim, including data appended after EOI', async () => {
+      const file = makeFile(jpegWithMetadata, 'photo.jpg', 'image/jpeg');
+      const result = await stripMediaMetadata(file);
+      const output = await bytesOf(result);
+
+      expect(output.slice(output.length - sosToEof.length)).toEqual(sosToEof);
+      const appended = ascii('APPENDED_PAYLOAD');
+      expect(output.slice(output.length - appended.length)).toEqual(appended);
+    });
+
+    it('preserves name, type, and lastModified', async () => {
+      const file = makeFile(jpegWithMetadata, 'photo.jpg', 'image/jpeg');
+      const result = await stripMediaMetadata(file);
+
+      expect(result.name).toBe('photo.jpg');
+      expect(result.type).toBe('image/jpeg');
+      expect(result.lastModified).toBe(file.lastModified);
+    });
+
+    it('returns the original file object when there is no metadata to remove', async () => {
+      const file = makeFile([...SOI, ...app0Jfif, ...dqt, ...sof0, ...dht, ...sosToEof], 'clean.jpg', 'image/jpeg');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns the original file when a segment length overruns the file', async () => {
+      const file = makeFile([...SOI, 0xff, 0xe1, 0xff, 0xff, 1, 2, 3], 'corrupt.jpg', 'image/jpeg');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns the original file when SOS is never reached', async () => {
+      const file = makeFile([...SOI, ...app1Exif, ...dqt], 'truncated.jpg', 'image/jpeg');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns the original file when marker structure is invalid', async () => {
+      const file = makeFile([...SOI, 0x00, 0x01, 0x02, 0x03], 'garbage.jpg', 'image/jpeg');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+  });
+
+  describe('png', () => {
+    it('removes tEXt, zTXt, iTXt, eXIf, tIME, and unknown ancillary chunks while keeping listed chunks', async () => {
+      const file = makeFile(pngWithMetadata, 'image.png', 'image/png');
+      const result = await stripMediaMetadata(file);
+
+      expect(result).not.toBe(file);
+      expect(await bytesOf(result)).toEqual(pngStripped);
+    });
+
+    it('keeps critical chunks and data appended after IEND', async () => {
+      const file = makeFile(pngWithMetadata, 'image.png', 'image/png');
+      const output = await bytesOf(await stripMediaMetadata(file));
+
+      expect(output.slice(0, 8)).toEqual(pngSignature);
+      for (const chunk of [ihdr, idat, iend]) {
+        expect(indexOfSequence(output, chunk)).toBeGreaterThanOrEqual(0);
+      }
+      expect(output.slice(output.length - pngTrailer.length)).toEqual(pngTrailer);
+    });
+
+    it('returns the original file object when there is no metadata to remove', async () => {
+      const file = makeFile([...pngSignature, ...ihdr, ...idat, ...iend], 'clean.png', 'image/png');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns the original file when a chunk length overruns the file', async () => {
+      const file = makeFile([...pngSignature, ...u32be(9999), ...ascii('tEXt'), 1, 2, 3], 'corrupt.png', 'image/png');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns the original file when IEND is missing', async () => {
+      const file = makeFile([...pngSignature, ...ihdr, ...text, ...idat], 'no-iend.png', 'image/png');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+  });
+
+  describe('webp', () => {
+    it('removes EXIF and XMP chunks, clears VP8X metadata flags, and fixes the RIFF size', async () => {
+      const file = makeFile(webpWithMetadata, 'image.webp', 'image/webp');
+      const result = await stripMediaMetadata(file);
+
+      expect(result).not.toBe(file);
+      expect(await bytesOf(result)).toEqual(webpStripped);
+    });
+
+    it('clears VP8X metadata flags even when no EXIF or XMP chunk is present', async () => {
+      const file = makeFile(riffWebp([vp8x, vp8]), 'flags-only.webp', 'image/webp');
+
+      expect(await bytesOf(await stripMediaMetadata(file))).toEqual(riffWebp([vp8xCleared, vp8]));
+    });
+
+    it('returns the original file object when there is no metadata to remove', async () => {
+      const file = makeFile(riffWebp([vp8]), 'clean.webp', 'image/webp');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns the original file when the RIFF size overruns the file', async () => {
+      const file = makeFile([...ascii('RIFF'), ...u32le(9999), ...ascii('WEBP'), ...vp8], 'corrupt.webp', 'image/webp');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns the original file when a chunk overruns the RIFF payload', async () => {
+      const file = makeFile(riffWebp([webpChunk('EXIF', [1, 2]).slice(0, 8)]), 'truncated.webp', 'image/webp');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+  });
+
+  describe('pass-through formats', () => {
+    it('returns GIF files unchanged, including comment extensions', async () => {
+      const gif = [...ascii('GIF89a'), 1, 0, 1, 0, 0x91, 0, 0, 0x21, 0xfe, 4, ...ascii('gps!'), 0, 0x3b];
+      const file = makeFile(gif, 'anim.gif', 'image/gif');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns mp4 files unchanged', async () => {
+      const mp4 = [...u32be(0x18), ...ascii('ftypmp42'), ...Array.from({ length: 16 }, () => 0)];
+      const file = makeFile(mp4, 'clip.mp4', 'video/mp4');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns webm files unchanged', async () => {
+      const file = makeFile([0x1a, 0x45, 0xdf, 0xa3, 1, 2, 3, 4], 'clip.webm', 'video/webm');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns unknown formats unchanged regardless of declared mime type', async () => {
+      const file = makeFile(ascii('not an image at all'), 'fake.jpg', 'image/jpeg');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns empty files unchanged', async () => {
+      const file = makeFile([], 'empty.jpg', 'image/jpeg');
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+
+    it('returns files over the size cap unchanged without reading them', async () => {
+      const file = makeFile(jpegWithMetadata, 'huge.jpg', 'image/jpeg');
+      Object.defineProperty(file, 'size', { value: 64 * 1024 * 1024 + 1 });
+
+      expect(await stripMediaMetadata(file)).toBe(file);
+    });
+  });
+});
+
+function indexOfSequence(haystack: number[], needle: number[]): number {
+  outer: for (let i = 0; i + needle.length <= haystack.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}

--- a/src/lib/media-metadata/strip-media-metadata.ts
+++ b/src/lib/media-metadata/strip-media-metadata.ts
@@ -3,7 +3,9 @@
  * (EXIF/GPS, XMP, IPTC, comments) from images before any upload provider sees
  * the bytes — catbox and similar hosts preserve files 1:1, so phone photos
  * would otherwise leak GPS coordinates. Containers are rewritten losslessly;
- * pixel data is never re-encoded. On any parse anomaly the original file is
+ * pixel data is never re-encoded, so the JPEG Exif Orientation tag (rotation
+ * lives in metadata, not pixels) is re-emitted as a minimal APP1 to keep
+ * photos from rendering sideways. On any parse anomaly the original file is
  * returned unchanged so an upload is never blocked.
  */
 
@@ -14,6 +16,9 @@ const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 
 /** JPEG segments removed: APP1 (Exif and XMP), APP13 (IPTC/Photoshop), COM. */
 const JPEG_DROPPED_MARKERS = new Set([0xe1, 0xed, 0xfe]);
+
+/** "Exif\0\0" — the payload prefix distinguishing an Exif APP1 from XMP. */
+const EXIF_APP1_HEADER = [0x45, 0x78, 0x69, 0x66, 0x00, 0x00];
 
 /**
  * PNG ancillary chunks kept because they affect rendering (plus APNG frames).
@@ -62,6 +67,7 @@ function stripJpeg(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | nu
   const len = bytes.length;
   const kept: Uint8Array<ArrayBuffer>[] = [bytes.subarray(0, 2)];
   let removedBytes = 0;
+  let orientation = 0;
   let pos = 2;
 
   for (;;) {
@@ -75,7 +81,11 @@ function stripJpeg(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | nu
     if (marker === 0xda) {
       // SOS: entropy-coded data follows and contains 0xff bytes that are not
       // segment markers, so copy verbatim to EOF instead of parsing. This
-      // also preserves data deliberately appended after EOI.
+      // also preserves data deliberately appended after EOI. Marker segments
+      // after the first SOS are deliberately left untouched: cameras write
+      // metadata before the first scan, and parsing entropy-coded data risks
+      // degrading exotic-but-valid files (e.g. motion-photo trailers) into
+      // full pass-through, which would strip less than this does.
       kept.push(bytes.subarray(pos, len));
       break;
     }
@@ -89,6 +99,9 @@ function stripJpeg(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | nu
     if (end > len) return null;
 
     if (JPEG_DROPPED_MARKERS.has(marker)) {
+      if (marker === 0xe1 && orientation === 0 && isExifApp1Payload(bytes, markerPos + 3, end)) {
+        orientation = readExifOrientation(bytes, markerPos + 9, end);
+      }
       removedBytes += end - pos;
     } else {
       kept.push(bytes.subarray(pos, end));
@@ -97,7 +110,56 @@ function stripJpeg(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | nu
   }
 
   if (removedBytes === 0) return null;
+  // Rotation lives in metadata, not pixels: re-emit the Orientation tag (and
+  // nothing else) as a minimal APP1 after SOI so photos don't render sideways.
+  if (orientation >= 2 && orientation <= 8) {
+    kept.splice(1, 0, buildOrientationApp1(orientation));
+  }
   return concat(kept);
+}
+
+function isExifApp1Payload(bytes: Uint8Array, start: number, end: number): boolean {
+  return start + EXIF_APP1_HEADER.length <= end && EXIF_APP1_HEADER.every((b, i) => bytes[start + i] === b);
+}
+
+/** Reads the Orientation tag (1-8) from IFD0 of an Exif TIFF block, or 0 when absent or malformed. */
+function readExifOrientation(bytes: Uint8Array, tiffStart: number, end: number): number {
+  if (tiffStart + 8 > end) return 0;
+  let little: boolean;
+  if (bytes[tiffStart] === 0x49 && bytes[tiffStart + 1] === 0x49) little = true;
+  else if (bytes[tiffStart] === 0x4d && bytes[tiffStart + 1] === 0x4d) little = false;
+  else return 0;
+  const readU16 = (pos: number) => (little ? bytes[pos] | (bytes[pos + 1] << 8) : (bytes[pos] << 8) | bytes[pos + 1]);
+  const readU32 = (pos: number) => (little ? readU32le(bytes, pos) : readU32be(bytes, pos));
+  if (readU16(tiffStart + 2) !== 42) return 0;
+  const ifdOffset = readU32(tiffStart + 4);
+  if (ifdOffset < 8) return 0;
+  const ifdPos = tiffStart + ifdOffset;
+  if (ifdPos + 2 > end) return 0;
+  const entryCount = readU16(ifdPos);
+  for (let i = 0; i < entryCount; i++) {
+    const entry = ifdPos + 2 + i * 12;
+    if (entry + 12 > end) return 0;
+    if (readU16(entry) !== 0x0112) continue;
+    // Orientation must be a single SHORT; the value sits in the first two payload bytes.
+    if (readU16(entry + 2) !== 3 || readU32(entry + 4) !== 1) return 0;
+    const value = readU16(entry + 8);
+    return value >= 1 && value <= 8 ? value : 0;
+  }
+  return 0;
+}
+
+/** Minimal little-endian Exif APP1 whose IFD0 holds only the Orientation tag. */
+function buildOrientationApp1(orientation: number): Uint8Array<ArrayBuffer> {
+  // prettier-ignore
+  return new Uint8Array([
+    0xff, 0xe1, 0x00, 0x22, // APP1, length 34
+    0x45, 0x78, 0x69, 0x66, 0x00, 0x00, // "Exif\0\0"
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, // "II", 42, IFD0 at offset 8
+    0x01, 0x00, // one IFD entry
+    0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, orientation, 0x00, 0x00, 0x00, // Orientation, SHORT x1
+    0x00, 0x00, 0x00, 0x00, // no next IFD
+  ]);
 }
 
 function stripPng(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | null {

--- a/src/lib/media-metadata/strip-media-metadata.ts
+++ b/src/lib/media-metadata/strip-media-metadata.ts
@@ -1,0 +1,208 @@
+/**
+ * Client-side media metadata stripping. Removes privacy-sensitive metadata
+ * (EXIF/GPS, XMP, IPTC, comments) from images before any upload provider sees
+ * the bytes — catbox and similar hosts preserve files 1:1, so phone photos
+ * would otherwise leak GPS coordinates. Containers are rewritten losslessly;
+ * pixel data is never re-encoded. On any parse anomaly the original file is
+ * returned unchanged so an upload is never blocked.
+ */
+
+/** Files larger than this pass through untouched to avoid large in-memory copies. */
+const MAX_PROCESSABLE_BYTES = 64 * 1024 * 1024;
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+/** JPEG segments removed: APP1 (Exif and XMP), APP13 (IPTC/Photoshop), COM. */
+const JPEG_DROPPED_MARKERS = new Set([0xe1, 0xed, 0xfe]);
+
+/**
+ * PNG ancillary chunks kept because they affect rendering (plus APNG frames).
+ * Critical chunks are always kept; ancillary chunks not listed here (tEXt,
+ * zTXt, iTXt, eXIf, tIME, and unknown ones) are dropped.
+ */
+const PNG_KEPT_ANCILLARY_CHUNKS = new Set(['tRNS', 'gAMA', 'cHRM', 'sRGB', 'iCCP', 'sBIT', 'bKGD', 'pHYs', 'acTL', 'fcTL', 'fdAT']);
+
+/** VP8X header flag bits announcing EXIF (0x08) and XMP (0x04) chunks. */
+const WEBP_VP8X_METADATA_FLAGS = 0x0c;
+
+/**
+ * Returns a copy of the file with image metadata removed, or the original
+ * file object unchanged when there is nothing to remove, the format is not
+ * handled (GIF, video, unknown), the file is too large, or parsing fails.
+ */
+export async function stripMediaMetadata(file: File): Promise<File> {
+  if (file.size > MAX_PROCESSABLE_BYTES) return file;
+  try {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const stripped = stripBytes(bytes);
+    if (stripped === null) return file;
+    return new File([stripped], file.name, { type: file.type, lastModified: file.lastModified });
+  } catch {
+    return file;
+  }
+}
+
+/** Detects the format by magic bytes (mime/extension are never trusted). Null means "keep original". */
+function stripBytes(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | null {
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return stripJpeg(bytes);
+  }
+  if (bytes.length >= 8 && PNG_SIGNATURE.every((b, i) => bytes[i] === b)) {
+    return stripPng(bytes);
+  }
+  if (bytes.length >= 16 && readFourCc(bytes, 0) === 'RIFF' && readFourCc(bytes, 8) === 'WEBP') {
+    return stripWebp(bytes);
+  }
+  // GIF passes through deliberately (rewriting animations is risky and GIFs
+  // carry no GPS-class metadata); video and unknown formats pass through too.
+  return null;
+}
+
+function stripJpeg(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | null {
+  const len = bytes.length;
+  const kept: Uint8Array<ArrayBuffer>[] = [bytes.subarray(0, 2)];
+  let removedBytes = 0;
+  let pos = 2;
+
+  for (;;) {
+    if (pos + 1 >= len || bytes[pos] !== 0xff) return null;
+    // A marker may be preceded by any number of 0xff fill bytes.
+    let markerPos = pos + 1;
+    while (markerPos < len && bytes[markerPos] === 0xff) markerPos++;
+    if (markerPos >= len) return null;
+    const marker = bytes[markerPos];
+
+    if (marker === 0xda) {
+      // SOS: entropy-coded data follows and contains 0xff bytes that are not
+      // segment markers, so copy verbatim to EOF instead of parsing. This
+      // also preserves data deliberately appended after EOI.
+      kept.push(bytes.subarray(pos, len));
+      break;
+    }
+    // Standalone markers (TEM, RST, SOI, EOI) are not expected before SOS.
+    if (marker === 0x00 || marker === 0x01 || (marker >= 0xd0 && marker <= 0xd9)) return null;
+
+    if (markerPos + 2 >= len) return null;
+    const segmentLength = (bytes[markerPos + 1] << 8) | bytes[markerPos + 2];
+    if (segmentLength < 2) return null;
+    const end = markerPos + 1 + segmentLength;
+    if (end > len) return null;
+
+    if (JPEG_DROPPED_MARKERS.has(marker)) {
+      removedBytes += end - pos;
+    } else {
+      kept.push(bytes.subarray(pos, end));
+    }
+    pos = end;
+  }
+
+  if (removedBytes === 0) return null;
+  return concat(kept);
+}
+
+function stripPng(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | null {
+  const len = bytes.length;
+  const kept: Uint8Array<ArrayBuffer>[] = [bytes.subarray(0, 8)];
+  let removedBytes = 0;
+  let pos = 8;
+
+  for (;;) {
+    if (pos + 8 > len) return null; // ran out of bytes before IEND
+    const dataLength = readU32be(bytes, pos);
+    if (dataLength > 0x7fffffff) return null;
+    const end = pos + 12 + dataLength; // length + type + data + CRC
+    if (end > len) return null;
+    const type = readFourCc(bytes, pos + 4);
+
+    if (type === 'IEND') {
+      // Keep IEND and any deliberately appended trailing data verbatim.
+      kept.push(bytes.subarray(pos, len));
+      break;
+    }
+
+    const isCritical = (bytes[pos + 4] & 0x20) === 0;
+    if (isCritical || PNG_KEPT_ANCILLARY_CHUNKS.has(type)) {
+      // Chunks are copied whole so their CRCs remain valid.
+      kept.push(bytes.subarray(pos, end));
+    } else {
+      removedBytes += end - pos;
+    }
+    pos = end;
+  }
+
+  if (removedBytes === 0) return null;
+  return concat(kept);
+}
+
+function stripWebp(bytes: Uint8Array<ArrayBuffer>): Uint8Array<ArrayBuffer> | null {
+  const len = bytes.length;
+  const riffEnd = 8 + readU32le(bytes, 4);
+  if (riffEnd < 12 || riffEnd > len) return null;
+
+  const kept: Uint8Array<ArrayBuffer>[] = [bytes.subarray(0, 12)];
+  let outLength = 12;
+  let removedBytes = 0;
+  let vp8xFlagsOffset = -1;
+  let vp8xHasMetadataFlags = false;
+  let pos = 12;
+
+  while (pos < riffEnd) {
+    if (pos + 8 > riffEnd) return null;
+    const fourCc = readFourCc(bytes, pos);
+    const chunkSize = readU32le(bytes, pos + 4);
+    const end = pos + 8 + chunkSize + (chunkSize & 1); // chunks are padded to even sizes
+    if (end > riffEnd) return null;
+
+    if (fourCc === 'EXIF' || fourCc === 'XMP ') {
+      removedBytes += end - pos;
+    } else {
+      if (fourCc === 'VP8X') {
+        if (chunkSize < 10) return null;
+        vp8xFlagsOffset = outLength + 8;
+        vp8xHasMetadataFlags = (bytes[pos + 8] & WEBP_VP8X_METADATA_FLAGS) !== 0;
+      }
+      kept.push(bytes.subarray(pos, end));
+      outLength += end - pos;
+    }
+    pos = end;
+  }
+
+  if (removedBytes === 0 && !vp8xHasMetadataFlags) return null;
+
+  if (riffEnd < len) kept.push(bytes.subarray(riffEnd, len)); // keep appended trailing data
+  const out = concat(kept);
+  writeU32le(out, 4, outLength - 8);
+  if (vp8xFlagsOffset >= 0) out[vp8xFlagsOffset] &= ~WEBP_VP8X_METADATA_FLAGS;
+  return out;
+}
+
+function concat(parts: Uint8Array<ArrayBuffer>[]): Uint8Array<ArrayBuffer> {
+  let total = 0;
+  for (const part of parts) total += part.length;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function readFourCc(bytes: Uint8Array, pos: number): string {
+  return String.fromCharCode(bytes[pos], bytes[pos + 1], bytes[pos + 2], bytes[pos + 3]);
+}
+
+function readU32be(bytes: Uint8Array, pos: number): number {
+  return ((bytes[pos] << 24) | (bytes[pos + 1] << 16) | (bytes[pos + 2] << 8) | bytes[pos + 3]) >>> 0;
+}
+
+function readU32le(bytes: Uint8Array, pos: number): number {
+  return (bytes[pos] | (bytes[pos + 1] << 8) | (bytes[pos + 2] << 16) | (bytes[pos + 3] << 24)) >>> 0;
+}
+
+function writeU32le(bytes: Uint8Array, pos: number, value: number): void {
+  bytes[pos] = value & 0xff;
+  bytes[pos + 1] = (value >>> 8) & 0xff;
+  bytes[pos + 2] = (value >>> 16) & 0xff;
+  bytes[pos + 3] = (value >>> 24) & 0xff;
+}


### PR DESCRIPTION
## Summary

Uploaded phone photos can leak GPS coordinates and other privacy-sensitive metadata: catbox and similar hosts preserve files 1:1. This PR strips metadata client-side on every upload route before any provider sees the bytes.

- **Lossless container rewrite** for JPEG (drops APP1 Exif/XMP, APP13 IPTC, COM), PNG (drops tEXt/zTXt/iTXt/eXIf/tIME and unknown ancillary chunks), and WebP (drops EXIF/XMP chunks, clears VP8X metadata flags, fixes RIFF size). Pixel data is never re-encoded.
- **GIF, video, and unknown formats pass through untouched**; any parse anomaly or I/O failure falls back to the original bytes so an upload is never blocked. 64MB size cap.
- Format detection is by magic bytes only; declared mime/extension are never trusted.

## Implementations (kept in lockstep)

| Route | Where |
|---|---|
| Web/renderer byte-egress points (catbox, generated media) | `src/lib/media-metadata/strip-media-metadata.ts` |
| Electron imgur/imgbb disk-path automation (bytes never transit JS) | `electron/strip-media-metadata.js` — main process strips to a temp copy (same basename) before CDP automation; original file on disk untouched |
| Android native picker (`pickAndUploadMedia`) | `android .../MediaMetadataStripper.java` — plugin sniffs magic bytes, strips picked images, and routes them through the existing generated-upload path so the original URI is never handed to a provider page; GIF/video are never read into memory |

## Tests

All three implementations share the same byte-level fixtures (metadata-laden JPEG/PNG/WebP, corrupt/truncated variants, pass-through formats):

- `src/lib/media-metadata/__tests__/strip-media-metadata.test.ts` (vitest)
- `electron/strip-media-metadata.test.js` (vitest, incl. temp-file lifecycle of `prepareStrippedUploadFile`)
- `android .../MediaMetadataStripperTest.java` (JUnit, runs on JVM)

## Verification

`yarn build`, `yarn lint`, `yarn type-check`, `yarn test` (1521 tests), `yarn knip` all green; Android `:app:testGithubDebugUnitTest` green (24 new tests, existing suites unbroken).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every media-upload path and custom binary parsers that rewrite files in memory (up to 64MB). Fail-open design and tests reduce the chance of blocking uploads, but a parser bug could still leak metadata or produce a slightly altered image.
> 
> **Overview**
> Strips privacy-sensitive image metadata (EXIF/GPS, XMP, IPTC, comments) on every upload path so hosts that preserve files 1:1 cannot leak phone-photo location data.
> 
> Lossless container rewrite for JPEG, PNG, and WebP (pixels never re-encoded). JPEG Orientation is re-emitted as a minimal APP1 so photos stay upright. GIF, video, unknown formats, files over 64MB, and parse failures pass through unchanged so uploads never block.
> 
> Three lockstep implementations: renderer `stripMediaMetadata` (catbox / generated bytes), Electron main-process temp copy for disk-path automation (original file untouched), and Android native picker (magic-byte sniff, then generated-upload path so the original URI is never given to a provider). Android/Electron upload failures now catch `Throwable`/`rm` errors so OOM or cleanup cannot hang or reject a successful upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afacde207fde97f7d2fac2cb2f71080e5af5fbbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically removes privacy-sensitive metadata from JPEG, PNG, and WebP files before upload.
  * Applies protection across mobile, desktop, automated, and hosted upload workflows.
  * Preserves filenames, MIME types, image data, rendering-critical properties, and valid JPEG orientation.

* **Bug Fixes**
  * Unsupported, oversized, malformed, or unreadable files continue uploading unchanged instead of being blocked.
  * Improved handling of upload failures and oversized picked files.

* **Tests**
  * Added coverage for metadata removal, orientation preservation, format handling, file preservation, size limits, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->