### PR TITLE
fix(settings): align account backup imports

### DIFF
--- a/src/components/settings-modal/account-settings/__tests__/account-settings.test.tsx
+++ b/src/components/settings-modal/account-settings/__tests__/account-settings.test.tsx
@@ -114,6 +114,7 @@ describe('AccountSettings', () => {
     });
     hookMocks.useAccounts.mockReturnValue({
       accounts: [{ id: 'test-id', name: 'Account 1', author: { shortAddress: '0x1...3' } }],
+      state: 'succeeded',
     });
 
     createObjectUrlSpy = vi.fn(() => 'blob:test-account');
@@ -192,6 +193,14 @@ describe('AccountSettings', () => {
     expect(buttonTexts.some((text) => text.includes('download_backup'))).toBe(true);
     expect(buttonTexts.some((text) => text.includes('import_account_backup'))).toBe(true);
     expect(buttonTexts.some((text) => text.includes('delete_account'))).toBe(true);
+  });
+
+  it('disables importing until the hooks account store is ready', () => {
+    hookMocks.useAccounts.mockReturnValue({ accounts: [], state: 'initializing' });
+
+    render();
+
+    expect(getButtonByText('import_account_backup').disabled).toBe(true);
   });
 
   it('shows generated-account copy for app-created accounts', () => {
@@ -324,7 +333,7 @@ describe('AccountSettings', () => {
       createdInput?.onchange?.({ target: { files: [file] } } as unknown as Event);
     });
 
-    expect(alertSpy).toHaveBeenCalledWith('Invalid JSON in file.');
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to parse account data:'));
     expect(hookMocks.importAccount).not.toHaveBeenCalled();
   });
 
@@ -448,12 +457,14 @@ describe('AccountSettings', () => {
     expect(importedPayload.account.pkcOptions).not.toHaveProperty('ipfsGatewayUrls');
   });
 
-  it('activates the resolved account name when an imported account name already exists', async () => {
+  it('activates the next available account name when imported suffixes already exist', async () => {
     hookMocks.useAccounts.mockReturnValue({
       accounts: [
         { id: 'test-id', name: 'Account 1', author: { shortAddress: '0x1...3' } },
         { id: 'existing-imported-id', name: 'Imported', author: { shortAddress: '0x9...9' } },
+        { id: 'existing-imported-2-id', name: 'Imported 2', author: { shortAddress: '0x8...8' } },
       ],
+      state: 'succeeded',
     });
     fileReaderState.result = JSON.stringify({
       account: {
@@ -479,7 +490,8 @@ describe('AccountSettings', () => {
     await flushMicrotasks();
 
     expect(hookMocks.importAccount).toHaveBeenCalledOnce();
-    expect(hookMocks.setActiveAccount).toHaveBeenCalledWith('Imported 2');
+    expect(hookMocks.setActiveAccount).toHaveBeenCalledWith('Imported 3');
+    expect(alertSpy).toHaveBeenCalledWith('Imported Imported 3');
   });
 
   it('surfaces import errors without navigating or reloading', async () => {

--- a/src/components/settings-modal/account-settings/account-settings.tsx
+++ b/src/components/settings-modal/account-settings/account-settings.tsx
@@ -5,12 +5,15 @@ import styles from './account-settings.module.css';
 import { getSettingsSectionPath } from '../../../lib/utils/route-utils';
 import { Capacitor } from '@capacitor/core';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { getLegacyDefaultBrowserHttpRoutersOptions } from '../../../lib/p2p-browser-config';
-import { getBrowserPureP2PAccountOptions, shouldUpgradeBrowserPureP2PAccount } from '../../../lib/p2p-runtime';
+import { isElectronRuntime } from '../../../lib/p2p-browser-config';
+import {
+  getImportedAccountActiveName,
+  processImportedAccount,
+  readImportedAccountAddresses,
+  rememberImportedAccountAddress,
+} from '../../../lib/utils/account-import-utils';
 
 const isAndroid = Capacitor.getPlatform() === 'android';
-const IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY = 'importedAccountAddresses';
-const IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY = 'importedAccountAddress';
 
 const safeParseJSON = <T,>(value: string): T | null => {
   try {
@@ -29,50 +32,10 @@ const withErrorHandling = async <T,>(fn: () => Promise<T>, onError: (e: unknown)
   }
 };
 
-const readImportedAccountAddresses = (): string[] => {
-  try {
-    const storedAddresses = localStorage.getItem(IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY);
-    const parsedAddresses = storedAddresses ? safeParseJSON<unknown>(storedAddresses) : null;
-    const normalizedAddresses = Array.isArray(parsedAddresses)
-      ? parsedAddresses.filter((address): address is string => typeof address === 'string' && address.length > 0)
-      : [];
-    const legacyAddress = localStorage.getItem(IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY);
-    return [...new Set(legacyAddress ? [...normalizedAddresses, legacyAddress] : normalizedAddresses)];
-  } catch (error) {
-    console.warn('Failed to read imported account addresses from localStorage:', error);
-    return [];
-  }
-};
-
-const rememberImportedAccountAddress = (address: string) => {
-  try {
-    const importedAddresses = readImportedAccountAddresses();
-    const nextImportedAddresses = [...new Set([...importedAddresses, address])];
-    localStorage.setItem(IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY, JSON.stringify(nextImportedAddresses));
-    localStorage.setItem(IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY, address);
-  } catch (error) {
-    console.warn('Failed to save imported account address to localStorage:', error);
-  }
-};
-
 const getSafeAccountBackupFileName = (accountName: string | undefined): string => {
   const safeName = (accountName || 'account').replace(/[^\w.-]/g, '_') || 'account';
   return `${safeName}.json`;
 };
-
-const getImportedAccountActiveName = (importedAccountName: string | undefined, accounts: Array<{ name?: string }>): string | undefined => {
-  if (!importedAccountName) {
-    return undefined;
-  }
-  return accounts.some((account) => account?.name === importedAccountName) ? `${importedAccountName} 2` : importedAccountName;
-};
-
-type ImportedAccountProtocolOptions = Record<string, unknown> & {
-  httpRoutersOptions?: unknown;
-};
-
-const toImportedAccountProtocolOptions = (protocolOptions: unknown): ImportedAccountProtocolOptions =>
-  protocolOptions && typeof protocolOptions === 'object' && !Array.isArray(protocolOptions) ? (protocolOptions as ImportedAccountProtocolOptions) : {};
 
 // Inner component keyed by account id so state resets when user switches account
 const AccountSettingsEditor = ({
@@ -82,8 +45,9 @@ const AccountSettingsEditor = ({
 }) => {
   const { t } = useTranslation();
   const location = useLocation();
-  const { accounts } = useAccounts();
+  const { accounts, state: accountsState } = useAccounts();
   const navigate = useNavigate();
+  const isElectron = isElectronRuntime(window);
 
   const _deleteAccount = (accountName: string) => {
     if (!accountName) {
@@ -148,55 +112,11 @@ const AccountSettingsEditor = ({
           return;
         }
 
-        const accountData = safeParseJSON<{
-          account?: {
-            communities?: Record<string, unknown>;
-            subscriptions?: string[];
-            author?: { address?: string };
-            name?: string;
-            pkcOptions?: ImportedAccountProtocolOptions;
-          };
-        }>(fileContent);
-        if (!accountData) {
-          alert('Invalid JSON in file.');
-          return;
-        }
-
-        if (accountData.account?.communities) {
-          const communityAddresses = Object.keys(accountData.account.communities);
-          if (!accountData.account.subscriptions) {
-            accountData.account.subscriptions = [];
-          }
-          const uniqueSubscriptions = [...accountData.account.subscriptions];
-          const knownSubscriptions = new Set(uniqueSubscriptions);
-          for (const address of communityAddresses) {
-            if (!knownSubscriptions.has(address)) {
-              uniqueSubscriptions.push(address);
-              knownSubscriptions.add(address);
-            }
-          }
-          accountData.account.subscriptions = uniqueSubscriptions;
-        }
-
-        const explicitImportedHttpRoutersOptions = toImportedAccountProtocolOptions(accountData.account?.pkcOptions).httpRoutersOptions;
-        if (accountData.account && !Array.isArray(explicitImportedHttpRoutersOptions)) {
-          accountData.account.pkcOptions = {
-            ...toImportedAccountProtocolOptions(accountData.account.pkcOptions),
-            httpRoutersOptions: getLegacyDefaultBrowserHttpRoutersOptions(),
-          };
-        }
-
-        if (accountData.account && shouldUpgradeBrowserPureP2PAccount(accountData.account)) {
-          accountData.account.pkcOptions = {
-            ...getBrowserPureP2PAccountOptions(accountData.account),
-            ...(Array.isArray(explicitImportedHttpRoutersOptions) ? { httpRoutersOptions: explicitImportedHttpRoutersOptions } : {}),
-          };
-        }
-
-        const modifiedAccountJson = JSON.stringify(accountData);
-        const importedAccountActiveName = getImportedAccountActiveName(accountData.account?.name, accounts);
         const result = await withErrorHandling(
           async () => {
+            const modifiedAccountJson = processImportedAccount(fileContent, isElectron);
+            const accountData = JSON.parse(modifiedAccountJson) as { account?: { author?: { address?: string }; name?: string } };
+            const importedAccountActiveName = getImportedAccountActiveName(accountData.account?.name, accounts);
             await importAccount(modifiedAccountJson);
             if (accountData.account?.author?.address) {
               rememberImportedAccountAddress(accountData.account.author.address);
@@ -204,7 +124,7 @@ const AccountSettingsEditor = ({
             if (importedAccountActiveName) {
               await setActiveAccount(importedAccountActiveName);
             }
-            return true;
+            return importedAccountActiveName;
           },
           (error) => {
             if (error instanceof Error) {
@@ -217,7 +137,7 @@ const AccountSettingsEditor = ({
         );
         if (result === undefined) return;
 
-        alert(`Imported ${accountData.account?.name}`);
+        alert(`Imported ${result}`);
         if (new URLSearchParams(location.search).get('section') !== 'account-settings') {
           navigate(getSettingsSectionPath(location.pathname, 'account-settings', location.search), { replace: true });
         }
@@ -255,7 +175,7 @@ const AccountSettingsEditor = ({
         <div className={styles.info}>{accountStorageInfo}</div>
       </div>
       <div>
-        <button type='button' onClick={handleImportAccount}>
+        <button type='button' disabled={accountsState !== 'succeeded'} onClick={handleImportAccount}>
           {t('import_account_backup')}
         </button>
         <button type='button' className={styles.deleteAccount} onClick={() => _deleteAccount(account?.name ?? '')}>

--- a/src/lib/utils/account-import-utils.test.ts
+++ b/src/lib/utils/account-import-utils.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDefaultElectronConfig,
+  getDefaultWebConfig,
+  getImportedAccountActiveName,
+  processImportedAccount,
+  readImportedAccountAddresses,
+  rememberImportedAccountAddress,
+} from './account-import-utils';
+import { shouldUpgradeBrowserPureP2PAccount } from '../p2p-runtime';
+
+const browserWindow = {} as Window;
+
+describe('imported account activation name', () => {
+  it('uses the imported name when it is available', () => {
+    expect(getImportedAccountActiveName('Account dress', [{ name: 'Account stitch' }])).toBe('Account dress');
+  });
+
+  it('uses the next available suffix when the imported name exists', () => {
+    const accounts = [{ name: 'Account dress' }, { name: 'Account dress 2' }, { name: 'Account dress 3' }];
+
+    expect(getImportedAccountActiveName('Account dress', accounts)).toBe('Account dress 4');
+  });
+
+  it('returns undefined when the imported backup has no account name', () => {
+    expect(getImportedAccountActiveName(undefined, [])).toBeUndefined();
+  });
+});
+
+describe('imported account metadata', () => {
+  it('rejects invalid backup shapes before calling hooks', () => {
+    expect(() => processImportedAccount('null', false, browserWindow)).toThrow('Account backup must be a JSON object.');
+    expect(() => processImportedAccount('{}', false, browserWindow)).toThrow('Account backup is missing account data.');
+  });
+
+  it('preserves legacy, short-address, and custom account names', () => {
+    for (const name of ['Account 1', 'Account dress', 'Personal']) {
+      const result = JSON.parse(processImportedAccount(JSON.stringify({ account: { name } }), false, browserWindow));
+      expect(result.account.name).toBe(name);
+    }
+  });
+
+  it('merges owned communities into subscriptions without duplicates', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({
+          account: {
+            communities: { 'business.eth': {}, 'music.bso': {} },
+            subscriptions: ['business.eth', 'technology.bso'],
+          },
+        }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(result.account.subscriptions).toEqual(['business.eth', 'technology.bso', 'music.bso']);
+  });
+
+  it('tracks every imported address while maintaining the legacy latest-address key', () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    rememberImportedAccountAddress('address-1', storage);
+    rememberImportedAccountAddress('address-2', storage);
+
+    expect(readImportedAccountAddresses(storage)).toEqual(['address-1', 'address-2']);
+    expect(storage.getItem('importedAccountAddress')).toBe('address-2');
+  });
+});
+
+describe('account import PKC options', () => {
+  it('includes only supported chain providers in platform defaults', () => {
+    expect(Object.keys(getDefaultWebConfig().chainProviders ?? {})).toEqual(['eth']);
+    expect(Object.keys(getDefaultElectronConfig().chainProviders ?? {})).toEqual(['eth']);
+  });
+
+  it('keeps only supported providers from current and legacy locations', () => {
+    const importedAccount = {
+      account: {
+        chainProviders: {
+          eth: { urls: ['https://eth.example'], chainId: 1 },
+          unknown: { urls: ['https://unknown.example'], chainId: 123 },
+        },
+        pkcOptions: {
+          pubsubKuboRpcClientsOptions: ['https://pubsub.example'],
+          chainProviders: {
+            eth: { urls: ['https://legacy-eth.example'], chainId: 1 },
+            unknown: { urls: ['https://legacy-unknown.example'], chainId: 123 },
+          },
+        },
+      },
+    };
+
+    const result = JSON.parse(processImportedAccount(JSON.stringify(importedAccount), false, browserWindow));
+
+    expect(result.account.chainProviders).toEqual({
+      eth: { urls: ['https://eth.example'], chainId: 1 },
+    });
+    expect(result.account.pkcOptions.chainProviders).toEqual({
+      eth: { urls: ['https://legacy-eth.example'], chainId: 1 },
+    });
+  });
+
+  it('preserves supported provider overrides when import replaces transport options with platform defaults', () => {
+    const importedAccount = {
+      account: {
+        pkcOptions: {
+          pubsubKuboRpcClientsOptions: ['https://pubsub.example'],
+          chainProviders: {
+            eth: { urls: ['https://custom-eth.example'], chainId: 1 },
+            unknown: { urls: ['https://unknown.example'], chainId: 123 },
+          },
+        },
+      },
+    };
+
+    const result = JSON.parse(processImportedAccount(JSON.stringify(importedAccount), true));
+
+    expect(result.account.pkcOptions.pkcRpcClientsOptions).toEqual(['ws://localhost:9138']);
+    expect(result.account.pkcOptions.chainProviders).toMatchObject({
+      eth: { urls: ['https://custom-eth.example'], chainId: 1 },
+    });
+    expect(Object.keys(result.account.pkcOptions.chainProviders)).toEqual(['eth']);
+  });
+
+  it('adds the legacy router baseline when imported protocol options omit routers', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({
+          account: {
+            pkcOptions: {
+              pubsubKuboRpcClientsOptions: ['https://pubsub.example'],
+            },
+          },
+        }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(result.account.pkcOptions.httpRoutersOptions).toEqual(getDefaultWebConfig().httpRoutersOptions);
+  });
+
+  it('preserves explicit custom and empty router lists', () => {
+    const customRouters = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({ account: { pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'], httpRoutersOptions: ['https://custom.example'] } } }),
+        false,
+        browserWindow,
+      ),
+    );
+    const emptyRouters = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({ account: { pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'], httpRoutersOptions: [] } } }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(customRouters.account.pkcOptions.httpRoutersOptions).toEqual(['https://custom.example']);
+    expect(emptyRouters.account.pkcOptions.httpRoutersOptions).toEqual([]);
+    expect(customRouters.account.pkcOptions.libp2pJsClientsOptions).toEqual([{ key: 'libp2pjs' }]);
+    expect(customRouters.account.pkcOptions.pubsubKuboRpcClientsOptions).toBeUndefined();
+    expect(shouldUpgradeBrowserPureP2PAccount(customRouters.account, browserWindow)).toBe(false);
+  });
+
+  it('preserves an already-modern browser libp2p configuration', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({
+          account: {
+            pkcOptions: {
+              libp2pJsClientsOptions: [{ key: 'libp2pjs', options: { bootstrap: ['custom-peer'] } }],
+              httpRoutersOptions: ['https://custom.example'],
+              resolveAuthorAddresses: true,
+            },
+          },
+        }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(result.account.pkcOptions.libp2pJsClientsOptions).toEqual([{ key: 'libp2pjs', options: { bootstrap: ['custom-peer'] } }]);
+    expect(result.account.pkcOptions.resolveAuthorAddresses).toBe(true);
+  });
+});

--- a/src/lib/utils/account-import-utils.test.ts
+++ b/src/lib/utils/account-import-utils.test.ts
@@ -25,6 +25,12 @@ describe('imported account activation name', () => {
   it('returns undefined when the imported backup has no account name', () => {
     expect(getImportedAccountActiveName(undefined, [])).toBeUndefined();
   });
+
+  it('tolerates account entries the hooks store has not hydrated yet', () => {
+    const accounts = [{ name: 'Account dress' }, undefined] as unknown as Array<{ name?: string }>;
+
+    expect(getImportedAccountActiveName('Account dress', accounts)).toBe('Account dress 2');
+  });
 });
 
 describe('imported account metadata', () => {
@@ -187,5 +193,38 @@ describe('account import PKC options', () => {
 
     expect(result.account.pkcOptions.libp2pJsClientsOptions).toEqual([{ key: 'libp2pjs', options: { bootstrap: ['custom-peer'] } }]);
     expect(result.account.pkcOptions.resolveAuthorAddresses).toBe(true);
+  });
+
+  it('preserves the backup router list when an electron import falls back to platform defaults', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({ account: { pkcOptions: { pubsubKuboRpcClientsOptions: ['https://pubsub.example'], httpRoutersOptions: ['https://custom.example'] } } }),
+        true,
+      ),
+    );
+
+    expect(result.account.pkcOptions.pkcRpcClientsOptions).toEqual(['ws://localhost:9138']);
+    expect(result.account.pkcOptions.httpRoutersOptions).toEqual(['https://custom.example']);
+  });
+
+  it('keeps a remote rpc endpoint that sits alongside a localhost entry', () => {
+    const result = JSON.parse(
+      processImportedAccount(
+        JSON.stringify({
+          account: { pkcOptions: { pkcRpcClientsOptions: ['ws://localhost:9138', 'wss://remote.example'], httpRoutersOptions: ['https://custom.example'] } },
+        }),
+        false,
+        browserWindow,
+      ),
+    );
+
+    expect(result.account.pkcOptions.pkcRpcClientsOptions).toEqual(['ws://localhost:9138', 'wss://remote.example']);
+    expect(result.account.pkcOptions.httpRoutersOptions).toEqual(['https://custom.example']);
+  });
+
+  it('falls back to platform defaults when the backup carries a non-object pkcOptions', () => {
+    const result = JSON.parse(processImportedAccount(JSON.stringify({ account: { pkcOptions: 'ws://localhost:9138' } }), true));
+
+    expect(result.account.pkcOptions).toEqual(getDefaultElectronConfig());
   });
 });

--- a/src/lib/utils/account-import-utils.ts
+++ b/src/lib/utils/account-import-utils.ts
@@ -1,0 +1,235 @@
+import { getSupportedChainProviders } from './chain-provider-utils';
+import { getBrowserPureP2PAccountOptions, shouldUpgradeBrowserPureP2PAccount } from '../p2p-runtime';
+
+interface PkcOptions {
+  ipfsGatewayUrls?: string[];
+  kuboRpcClientsOptions?: unknown[];
+  libp2pJsClientsOptions?: unknown[];
+  pubsubKuboRpcClientsOptions?: string[];
+  pubsubHttpClientsOptions?: unknown[];
+  pkcRpcClientsOptions?: string[];
+  httpRoutersOptions?: string[];
+  chainProviders?: {
+    [key: string]: {
+      urls: string[];
+      chainId: number;
+    };
+  };
+  resolveAuthorAddresses?: boolean;
+  validatePages?: boolean;
+  [key: string]: unknown;
+}
+
+interface ImportedAccount {
+  account?: {
+    author?: { address?: string };
+    chainProviders?: PkcOptions['chainProviders'];
+    communities?: Record<string, unknown>;
+    name?: string;
+    pkcOptions?: PkcOptions;
+    subscriptions?: string[];
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+const IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY = 'importedAccountAddresses';
+const IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY = 'importedAccountAddress';
+
+export const readImportedAccountAddresses = (storage: Pick<Storage, 'getItem'> = localStorage): string[] => {
+  try {
+    const storedAddresses = storage.getItem(IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY);
+    const parsedAddresses: unknown = storedAddresses ? JSON.parse(storedAddresses) : null;
+    const normalizedAddresses = Array.isArray(parsedAddresses)
+      ? parsedAddresses.filter((address): address is string => typeof address === 'string' && address.length > 0)
+      : [];
+    const legacyAddress = storage.getItem(IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY);
+    return [...new Set(legacyAddress ? [...normalizedAddresses, legacyAddress] : normalizedAddresses)];
+  } catch (error) {
+    console.warn('Failed to read imported account addresses from localStorage:', error);
+    return [];
+  }
+};
+
+export const rememberImportedAccountAddress = (address: string, storage: Pick<Storage, 'getItem' | 'setItem'> = localStorage) => {
+  try {
+    const importedAddresses = readImportedAccountAddresses(storage);
+    storage.setItem(IMPORTED_ACCOUNT_ADDRESSES_STORAGE_KEY, JSON.stringify([...new Set([...importedAddresses, address])]));
+    storage.setItem(IMPORTED_ACCOUNT_ADDRESS_LEGACY_STORAGE_KEY, address);
+  } catch (error) {
+    console.warn('Failed to save imported account address to localStorage:', error);
+  }
+};
+
+export const getImportedAccountActiveName = (importedAccountName: string | undefined, accounts: Array<{ name?: string }>): string | undefined => {
+  if (!importedAccountName) {
+    return undefined;
+  }
+
+  const accountNames = new Set(accounts.map((account) => account.name));
+  if (!accountNames.has(importedAccountName)) {
+    return importedAccountName;
+  }
+
+  let suffix = 2;
+  while (accountNames.has(`${importedAccountName} ${suffix}`)) {
+    suffix += 1;
+  }
+  return `${importedAccountName} ${suffix}`;
+};
+
+// Default configuration for web/mobile platforms
+export const getDefaultWebConfig = (): PkcOptions => ({
+  ipfsGatewayUrls: ['https://ipfsgateway.xyz', 'https://gateway.plebpubsub.xyz', 'https://gateway.forumindex.com'],
+  pubsubKuboRpcClientsOptions: ['https://pubsubprovider.xyz/api/v0', 'https://plebpubsub.xyz/api/v0', 'https://rannithepleb.com/api/v0'],
+  httpRoutersOptions: ['https://routing.lol', 'https://peers.pleb.bot', 'https://peers.plebpubsub.xyz', 'https://peers.forumindex.com'],
+  chainProviders: {
+    eth: {
+      urls: ['ethers.js', 'https://ethrpc.xyz', 'viem'],
+      chainId: 1,
+    },
+  },
+  resolveAuthorAddresses: false,
+  validatePages: false,
+});
+
+// Default configuration for Electron platform
+export const getDefaultElectronConfig = (): PkcOptions => ({
+  pkcRpcClientsOptions: ['ws://localhost:9138'],
+  httpRoutersOptions: ['https://peers.pleb.bot', 'https://routing.lol', 'https://peers.forumindex.com', 'https://peers.plebpubsub.xyz'],
+  chainProviders: {
+    eth: {
+      urls: ['ethers.js', 'https://ethrpc.xyz', 'viem'],
+      chainId: 1,
+    },
+  },
+  resolveAuthorAddresses: false,
+  validatePages: false,
+});
+
+// Check if RPC URL is localhost
+const isLocalhostRpc = (url: string): boolean => {
+  return url.includes('localhost') || url.includes('127.0.0.1');
+};
+
+// Check if account has non-localhost RPC configuration
+const hasNonLocalhostRpc = (options: PkcOptions): boolean => {
+  const hasRpcOptions = (options.pkcRpcClientsOptions?.length ?? 0) > 0;
+  return hasRpcOptions && !options.pkcRpcClientsOptions?.some(isLocalhostRpc);
+};
+
+// Check if account has pubsub providers configured
+const hasPubsubProviders = (options: PkcOptions): boolean => {
+  return (options.pubsubKuboRpcClientsOptions?.length ?? 0) > 0 || (options.ipfsGatewayUrls?.length ?? 0) > 0;
+};
+
+const hasBrowserLibp2pProvider = (options: PkcOptions): boolean => (options.libp2pJsClientsOptions?.length ?? 0) > 0;
+
+// Check if account has localhost RPC configured
+const hasLocalhostRpc = (options: PkcOptions): boolean => {
+  const hasRpcOptions = (options.pkcRpcClientsOptions?.length ?? 0) > 0;
+  return hasRpcOptions && (options.pkcRpcClientsOptions?.some(isLocalhostRpc) ?? false);
+};
+
+/**
+ * Transforms PKC options for imported accounts based on platform and existing configuration
+ *
+ * Logic:
+ * - Preserves non-localhost RPC configurations
+ * - On Electron: replaces pubsub providers with localhost RPC
+ * - On Web: replaces localhost RPC with pubsub providers
+ * - Sets platform-appropriate defaults for missing configurations
+ */
+export const transformPkcOptionsForImport = (importedAccount: ImportedAccount, isElectron: boolean): PkcOptions => {
+  const importedOptions = importedAccount.account?.pkcOptions || {};
+  const currentOptions = {
+    ...importedOptions,
+    chainProviders: getSupportedChainProviders(importedOptions.chainProviders),
+  };
+  const getPlatformDefaults = () => {
+    const defaults = isElectron ? getDefaultElectronConfig() : getDefaultWebConfig();
+    if (!currentOptions.chainProviders) return defaults;
+
+    return {
+      ...defaults,
+      chainProviders: {
+        ...defaults.chainProviders,
+        ...currentOptions.chainProviders,
+      },
+    };
+  };
+
+  // Don't overwrite non-localhost RPC configurations
+  if (hasNonLocalhostRpc(currentOptions)) {
+    return currentOptions;
+  }
+
+  if (isElectron) {
+    // On electron: if account has pubsub providers, replace with localhost RPC
+    if (hasPubsubProviders(currentOptions)) {
+      return getPlatformDefaults();
+    }
+    // If already has localhost RPC or no providers, use electron defaults
+    return (currentOptions.pkcRpcClientsOptions?.length ?? 0) > 0 ? currentOptions : getPlatformDefaults();
+  } else {
+    // On web: if account has localhost RPC, replace with pubsub providers
+    if (hasLocalhostRpc(currentOptions)) {
+      return getPlatformDefaults();
+    }
+    // Preserve both current browser transports; missing transports use web defaults.
+    return hasBrowserLibp2pProvider(currentOptions) || hasPubsubProviders(currentOptions) ? currentOptions : getPlatformDefaults();
+  }
+};
+
+/**
+ * Processes an imported account by transforming its PKC options
+ * Returns the modified account as a JSON string ready for import
+ */
+export const processImportedAccount = (accountJson: string, isElectron: boolean, targetWindow?: Window): string => {
+  let importedAccount: ImportedAccount;
+
+  try {
+    const parsedAccount: unknown = JSON.parse(accountJson);
+    if (!parsedAccount || typeof parsedAccount !== 'object' || Array.isArray(parsedAccount)) {
+      throw new Error('Account backup must be a JSON object.');
+    }
+    importedAccount = parsedAccount as ImportedAccount;
+  } catch (error) {
+    throw new Error(`Failed to parse account data: ${error instanceof Error ? error.message : 'Unknown parsing error'}`);
+  }
+
+  if (!importedAccount.account || typeof importedAccount.account !== 'object' || Array.isArray(importedAccount.account)) {
+    throw new Error('Account backup is missing account data.');
+  }
+  if (importedAccount.account.communities) {
+    const subscriptions = Array.isArray(importedAccount.account.subscriptions) ? importedAccount.account.subscriptions : [];
+    importedAccount.account.subscriptions = [...new Set([...subscriptions, ...Object.keys(importedAccount.account.communities)])];
+  }
+  const explicitImportedHttpRoutersOptions = importedAccount.account.pkcOptions?.httpRoutersOptions;
+
+  if (importedAccount.account.chainProviders) {
+    importedAccount.account.chainProviders = getSupportedChainProviders(importedAccount.account.chainProviders);
+  }
+
+  if (importedAccount.account.pkcOptions && !Array.isArray(importedAccount.account.pkcOptions.httpRoutersOptions)) {
+    importedAccount.account.pkcOptions.httpRoutersOptions = (isElectron ? getDefaultElectronConfig() : getDefaultWebConfig()).httpRoutersOptions;
+  }
+
+  // Transform pkcOptions based on platform and existing config
+  if (importedAccount.account.pkcOptions) {
+    importedAccount.account.pkcOptions = transformPkcOptionsForImport(importedAccount, isElectron);
+  } else {
+    // If no pkcOptions exist, set defaults based on platform
+    importedAccount.account.pkcOptions = isElectron ? getDefaultElectronConfig() : getDefaultWebConfig();
+  }
+
+  const browserWindow = targetWindow ?? (typeof window === 'undefined' ? undefined : window);
+  if (!isElectron && browserWindow && shouldUpgradeBrowserPureP2PAccount(importedAccount.account, browserWindow)) {
+    importedAccount.account.pkcOptions = {
+      ...getBrowserPureP2PAccountOptions(importedAccount.account),
+      ...(Array.isArray(explicitImportedHttpRoutersOptions) ? { httpRoutersOptions: explicitImportedHttpRoutersOptions } : {}),
+    };
+  }
+
+  return JSON.stringify(importedAccount);
+};

--- a/src/lib/utils/account-import-utils.ts
+++ b/src/lib/utils/account-import-utils.ts
@@ -66,7 +66,7 @@ export const getImportedAccountActiveName = (importedAccountName: string | undef
     return undefined;
   }
 
-  const accountNames = new Set(accounts.map((account) => account.name));
+  const accountNames = new Set(accounts.map((account) => account?.name));
   if (!accountNames.has(importedAccountName)) {
     return importedAccountName;
   }
@@ -112,10 +112,11 @@ const isLocalhostRpc = (url: string): boolean => {
   return url.includes('localhost') || url.includes('127.0.0.1');
 };
 
-// Check if account has non-localhost RPC configuration
+// Check if account has at least one non-localhost RPC endpoint. A mixed list counts, so importing never
+// discards a reachable remote node just because a localhost entry sits alongside it.
 const hasNonLocalhostRpc = (options: PkcOptions): boolean => {
   const hasRpcOptions = (options.pkcRpcClientsOptions?.length ?? 0) > 0;
-  return hasRpcOptions && !options.pkcRpcClientsOptions?.some(isLocalhostRpc);
+  return hasRpcOptions && (options.pkcRpcClientsOptions?.some((url) => !isLocalhostRpc(url)) ?? false);
 };
 
 // Check if account has pubsub providers configured
@@ -205,6 +206,12 @@ export const processImportedAccount = (accountJson: string, isElectron: boolean,
     const subscriptions = Array.isArray(importedAccount.account.subscriptions) ? importedAccount.account.subscriptions : [];
     importedAccount.account.subscriptions = [...new Set([...subscriptions, ...Object.keys(importedAccount.account.communities)])];
   }
+  const importedPkcOptions: unknown = importedAccount.account.pkcOptions;
+  if (importedPkcOptions && (typeof importedPkcOptions !== 'object' || Array.isArray(importedPkcOptions))) {
+    // A hand-edited backup can carry a non-object pkcOptions; drop it so platform defaults apply instead
+    // of assigning properties onto a primitive, which throws in strict mode.
+    importedAccount.account.pkcOptions = undefined;
+  }
   const explicitImportedHttpRoutersOptions = importedAccount.account.pkcOptions?.httpRoutersOptions;
 
   if (importedAccount.account.chainProviders) {
@@ -216,20 +223,26 @@ export const processImportedAccount = (accountJson: string, isElectron: boolean,
   }
 
   // Transform pkcOptions based on platform and existing config
+  let normalizedPkcOptions: PkcOptions;
   if (importedAccount.account.pkcOptions) {
-    importedAccount.account.pkcOptions = transformPkcOptionsForImport(importedAccount, isElectron);
+    normalizedPkcOptions = transformPkcOptionsForImport(importedAccount, isElectron);
   } else {
     // If no pkcOptions exist, set defaults based on platform
-    importedAccount.account.pkcOptions = isElectron ? getDefaultElectronConfig() : getDefaultWebConfig();
+    normalizedPkcOptions = isElectron ? getDefaultElectronConfig() : getDefaultWebConfig();
   }
+  importedAccount.account.pkcOptions = normalizedPkcOptions;
 
   const browserWindow = targetWindow ?? (typeof window === 'undefined' ? undefined : window);
   if (!isElectron && browserWindow && shouldUpgradeBrowserPureP2PAccount(importedAccount.account, browserWindow)) {
-    importedAccount.account.pkcOptions = {
-      ...getBrowserPureP2PAccountOptions(importedAccount.account),
-      ...(Array.isArray(explicitImportedHttpRoutersOptions) ? { httpRoutersOptions: explicitImportedHttpRoutersOptions } : {}),
-    };
+    normalizedPkcOptions = getBrowserPureP2PAccountOptions(importedAccount.account);
   }
+
+  // Platform defaults and the pure-P2P upgrade both replace the whole options object, so restore the backup's
+  // explicit router list last; otherwise importing on Electron silently drops custom routers.
+  if (Array.isArray(explicitImportedHttpRoutersOptions)) {
+    normalizedPkcOptions.httpRoutersOptions = explicitImportedHttpRoutersOptions;
+  }
+  importedAccount.account.pkcOptions = normalizedPkcOptions;
 
   return JSON.stringify(importedAccount);
 };

--- a/src/lib/utils/chain-provider-utils.ts
+++ b/src/lib/utils/chain-provider-utils.ts
@@ -1,0 +1,11 @@
+const SUPPORTED_CHAIN_PROVIDER_TICKERS: ReadonlySet<string> = new Set(['eth']);
+
+export const getSupportedChainProviders = <T>(chainProviders: Record<string, T> | undefined): Record<string, T> | undefined => {
+  if (!chainProviders) return undefined;
+
+  const supportedChainProviders: Record<string, T> = {};
+  for (const [ticker, provider] of Object.entries(chainProviders)) {
+    if (SUPPORTED_CHAIN_PROVIDER_TICKERS.has(ticker)) supportedChainProviders[ticker] = provider;
+  }
+  return supportedChainProviders;
+};


### PR DESCRIPTION
## Summary

- extract account-backup normalization into the same shared utilities and behavior used by Seedit
- choose the next available account-name suffix, retain imported address metadata, and avoid a page reload after activation
- preserve compatible browser transport and chain-provider settings and gate import until the accounts store is ready

## Verification

- 1,555 Vitest tests passed with the repository coverage gate
- build, lint, type-check, Knip, and changed-scope React Doctor passed
- Chrome, Firefox, and WebKit desktop/mobile import flows passed
- throttled Chromium confirmed the import readiness gate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how imported accounts are wired for P2P/RPC and activated, which can affect connectivity after restore; coverage is strong but behavior is user-data sensitive.
> 
> **Overview**
> Moves account-backup parsing, naming, localStorage tracking, and **PKC/network normalization** out of account settings into **`account-import-utils`** (plus **`getSupportedChainProviders`** for `eth` only).
> 
> **Import UX:** the backup button stays **disabled** until `useAccounts` reaches **`succeeded`**, so duplicate-name resolution uses a hydrated account list. Colliding names now pick the **next free suffix** (e.g. `Imported 3`), and the success alert shows that **resolved** name—not the raw backup name.
> 
> **Backup processing:** stricter validation and clearer parse errors; merges **communities** into **subscriptions**; applies **web vs Electron** defaults (pubsub vs localhost RPC) while keeping explicit **HTTP routers**, mixed RPC lists, libp2p upgrades, and supported chain overrides where tests define compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f05d5dc5c223d3c85d4fa5b82f6c6bf143552a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved account backup imports with validation, normalization, and unique account naming.
  * Preserved compatible subscriptions, network settings, and provider configurations across web and desktop imports.
  * Added support for remembering previously imported account addresses.
  * Added platform-aware handling for browser and desktop network configurations.

* **Bug Fixes**
  * Disabled account importing while account data is still loading.
  * Improved invalid backup error messages.
  * Prevented duplicate supported chain providers and community subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->