### PR TITLE
fix(publishing): reset display name after account switch

### DIFF
--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -784,7 +784,7 @@ describe('PostForm', () => {
     await dispatchInput(textarea, 'Account switch regression');
     await clickByText(table, 'post');
 
-    expect(testState.publishedPostOptions?.displayName).toBeUndefined();
+    expect(testState.publishPostMock).toHaveBeenCalledWith(expect.objectContaining({ displayName: undefined }));
   });
 
   it('converts YouTube links to thumbnail file links on media-only post forms', async () => {

--- a/src/components/post-form/__tests__/post-form.test.tsx
+++ b/src/components/post-form/__tests__/post-form.test.tsx
@@ -16,7 +16,7 @@ const testState = vi.hoisted(() => ({
   account: {
     author: { address: 'alice.eth', displayName: 'Alice' },
     subscriptions: ['music-posting.eth'],
-  },
+  } as { author?: { address?: string; displayName?: string }; subscriptions?: string[] },
   accountComment: undefined as { communityAddress?: string } | undefined,
   bestAvailableYouTubeThumbnailMock: undefined as undefined | ((link: string) => Promise<string | undefined>),
   accountCommunityAddresses: ['mod.eth'] as string[],
@@ -757,6 +757,36 @@ describe('PostForm', () => {
     expect(testState.setPublishPostOptionsMock).toHaveBeenCalledWith({ communityAddress: 'music-posting.eth' });
   });
 
+  it('does not reuse the previous account display name after switching to an anonymous account', async () => {
+    testState.account = {
+      author: { address: 'dev-account.bso', displayName: 'Old Dev Name' },
+      subscriptions: ['music-posting.eth'],
+    };
+    testState.resolvedCommunityAddress = 'music-posting.eth';
+
+    await renderPostForm('/mu');
+    await clickByText(container, 'start_new_thread');
+
+    const devNameInput = container.querySelectorAll<HTMLInputElement>('input[type="text"]')[0];
+    await dispatchInput(devNameInput, '5chan Dev');
+    expect(testState.publishPostOptions.displayName).toBe('5chan Dev');
+
+    testState.account = {
+      author: { address: 'anonymous-account' },
+      subscriptions: ['music-posting.eth'],
+    };
+    await renderPostForm('/mu');
+
+    const table = container.querySelector('table') as HTMLTableElement;
+    const nameInput = table.querySelectorAll<HTMLInputElement>('input[type="text"]')[0];
+    const textarea = table.querySelector('textarea') as HTMLTextAreaElement;
+    expect(nameInput.value).toBe('');
+    await dispatchInput(textarea, 'Account switch regression');
+    await clickByText(table, 'post');
+
+    expect(testState.publishedPostOptions?.displayName).toBeUndefined();
+  });
+
   it('converts YouTube links to thumbnail file links on media-only post forms', async () => {
     const youtubeLink = 'https://www.youtube.com/watch?v=abc123';
     const thumbnailLink = 'https://img.youtube.com/vi/abc123/maxresdefault.jpg';
@@ -1019,7 +1049,10 @@ describe('PostForm', () => {
     expect(linkInput.value).toBe(twimgLink);
     expect(testState.publishPostMock).toHaveBeenCalledTimes(1);
     expect(testState.publishPostMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'Twimg thread',
+      displayName: 'Alice',
+      flairs: undefined,
       link: publishLink,
     });
     expect(testState.publishedPostOptions?.link).toBe(publishLink);
@@ -1141,7 +1174,10 @@ describe('PostForm', () => {
 
     await clickByText(table as HTMLTableElement, 'post');
     expect(testState.publishPostMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'saved board draft',
+      displayName: 'Alice',
+      flairs: undefined,
       link: 'https://example.com/saved.png',
       spoiler: true,
       title: 'Saved subject',
@@ -1188,6 +1224,7 @@ describe('PostForm', () => {
 
     expect(testState.publishPostMock).toHaveBeenCalledWith({
       content: 'flagged post',
+      displayName: 'Alice',
       challengeRequest: {
         challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
       },
@@ -1219,6 +1256,7 @@ describe('PostForm', () => {
 
     expect(testState.publishPostMock).toHaveBeenCalledWith({
       content: 'candidate board flag post',
+      displayName: 'Alice',
       challengeRequest: {
         challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
       },
@@ -1243,6 +1281,7 @@ describe('PostForm', () => {
 
     expect(testState.publishPostMock).toHaveBeenCalledWith({
       content: 'sports post',
+      displayName: 'Alice',
       challengeRequest: {
         challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
       },
@@ -1265,7 +1304,9 @@ describe('PostForm', () => {
     await clickByText(table as HTMLTableElement, 'post');
 
     expect(testState.publishPostMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'memeflag post',
+      displayName: 'Alice',
       flairs: [{ type: 'pol', code: 'AC', text: 'flag:pol:AC' }],
     });
   });
@@ -1303,7 +1344,9 @@ describe('PostForm', () => {
     await clickByText(table as HTMLTableElement, 'post');
 
     expect(testState.publishPostMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'flash thread',
+      displayName: 'Alice',
       flairs: [{ text: 'flash:loop' }],
     });
   });
@@ -1323,7 +1366,10 @@ describe('PostForm', () => {
     await clickByText(table as HTMLTableElement, 'post');
 
     expect(testState.publishPostMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'flash thread',
+      displayName: 'Alice',
+      flairs: undefined,
     });
   });
 
@@ -1365,7 +1411,10 @@ describe('PostForm', () => {
 
     expect(testState.publishPostMock).toHaveBeenCalledTimes(1);
     expect(testState.publishPostMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'fortune body[fortune color=#fd4d32]Excellent Luck[/fortune]',
+      displayName: 'Alice',
+      flairs: undefined,
     });
     randomSpy.mockRestore();
   });
@@ -2207,7 +2256,10 @@ describe('PostForm', () => {
     expect(linkInput.value).toBe(twimgLink);
     expect(testState.publishReplyMock).toHaveBeenCalledTimes(1);
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'Twimg reply',
+      displayName: 'Alice',
+      flairs: undefined,
       link: publishLink,
     });
   });

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { type ReactNode, type Ref, useCallback, useEffect, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { Trans, useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
@@ -159,6 +159,7 @@ interface PostFormFieldsProps {
   t: TFunction;
   account: ReturnType<typeof useAccount>;
   displayName: string | undefined;
+  nameRef: Ref<HTMLInputElement>;
   bbcodePreviewContent: string;
   isInPostView: boolean;
   isBbcodePreviewing: boolean;
@@ -216,6 +217,7 @@ const PostFormFields = ({
   t,
   account,
   displayName,
+  nameRef,
   bbcodePreviewContent,
   isInPostView,
   isBbcodePreviewing,
@@ -273,7 +275,9 @@ const PostFormFields = ({
       <td>{t('name')}</td>
       <td>
         <input
+          key={account?.id ?? account?.name ?? account?.author?.address}
           type='text'
+          ref={nameRef}
           aria-label={t('name')}
           placeholder={!displayName ? capitalize(t('anonymous')) : undefined}
           defaultValue={displayName || undefined}
@@ -686,6 +690,7 @@ const PostFormTable = ({ closeForm, draftKey, hideForm, postCid }: { closeForm: 
   const effectiveBoardAddress = communityAddress || draft.communityAddress || publishPostOptions.communityAddress;
 
   const textRef = useRef<HTMLTextAreaElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
   const urlRef = useRef<HTMLInputElement>(null);
   const subjectRef = useRef<HTMLInputElement>(null);
   const optionsRef = useRef<HTMLInputElement>(null);
@@ -799,6 +804,7 @@ const PostFormTable = ({ closeForm, draftKey, hideForm, postCid }: { closeForm: 
       const appliedYouTubeConversion = await applyPendingConversion();
 
       const currentTitle = subjectRef.current?.value.trim() || '';
+      const currentDisplayName = nameRef.current?.value.trim() || undefined;
       const currentContent = textRef.current?.value || '';
       const currentUrl = urlRef.current?.value.trim() || '';
       const currentOptions = optionsRef.current?.value || '';
@@ -862,6 +868,7 @@ const PostFormTable = ({ closeForm, draftKey, hideForm, postCid }: { closeForm: 
       nonokoRedirectPathRef.current = hasNonokoOption(currentOptions) ? getBoardIndexPath() : null;
       pendingPostBoardPathRef.current = pendingPostBoardPath;
       await publishPost({
+        displayName: currentDisplayName,
         content: publishContent,
         ...getPublishLinkOptions(currentUrl, appliedYouTubeConversion || (hasRestoredDraftRef.current && Boolean(currentUrl))),
         ...publishOptions,
@@ -960,6 +967,7 @@ const PostFormTable = ({ closeForm, draftKey, hideForm, postCid }: { closeForm: 
       const appliedYouTubeConversion = await applyPendingConversion();
 
       const currentUrl = urlRef.current?.value.trim() || '';
+      const currentDisplayName = nameRef.current?.value.trim() || undefined;
       const currentOptions = optionsRef.current?.value || '';
       const currentOptionsError = getPostOptionsValidationError(currentOptions, postOptionsDirectoryCode);
       const publishContent = getContentWithOptions(textRef.current?.value || '', currentOptions, fortuneEntryRef, diceRollRef, postOptionsDirectoryCode);
@@ -1009,6 +1017,7 @@ const PostFormTable = ({ closeForm, draftKey, hideForm, postCid }: { closeForm: 
 
       nonokoRedirectPathRef.current = hasNonokoOption(currentOptions) ? getBoardIndexPath() : null;
       await publishReply({
+        displayName: currentDisplayName,
         content: publishContent,
         ...getPublishLinkOptions(currentUrl, appliedYouTubeConversion || (hasRestoredDraftRef.current && Boolean(currentUrl))),
         ...flagPublishOptions,
@@ -1094,18 +1103,6 @@ const PostFormTable = ({ closeForm, draftKey, hideForm, postCid }: { closeForm: 
   const uploadMode = useMediaHostingStore((state) => state.uploadMode);
   const showUploadControls = getShowUploadControls(uploadMode, isWebRuntime());
 
-  const hasInitializedDisplayName = useRef(false);
-  useEffect(() => {
-    if (displayName && !hasInitializedDisplayName.current) {
-      hasInitializedDisplayName.current = true;
-      if (isInPostView) {
-        setPublishReplyOptions({ displayName });
-      } else {
-        setPublishPostOptions({ displayName });
-      }
-    }
-  }, [displayName, isInPostView, setPublishReplyOptions, setPublishPostOptions]);
-
   return (
     <>
       <table className={styles.postFormTable}>
@@ -1114,6 +1111,7 @@ const PostFormTable = ({ closeForm, draftKey, hideForm, postCid }: { closeForm: 
             t={t}
             account={account}
             displayName={displayName}
+            nameRef={nameRef}
             bbcodePreviewContent={bbcodePreviewContent}
             isInPostView={isInPostView}
             isBbcodePreviewing={isBbcodePreviewing}

--- a/src/components/reply-modal/__tests__/reply-modal.test.tsx
+++ b/src/components/reply-modal/__tests__/reply-modal.test.tsx
@@ -554,7 +554,22 @@ describe('ReplyModal', () => {
     expect(container.textContent).toContain('Spoiler?');
     expect(container.textContent).toContain('posts_last_synced_info:{"time":"ago:1000"}');
     expect(testState.setPublishReplyOptionsMock).toHaveBeenCalledWith({ content: '>>42\nselected text' });
-    expect(testState.setPublishReplyOptionsMock).toHaveBeenCalledWith({ displayName: 'Alice' });
+  });
+
+  it('publishes without the previous account display name after switching to an anonymous account', async () => {
+    await renderReplyModal('/mu/thread/post-1');
+
+    testState.account = { author: { address: 'anonymous-account' } };
+    await rerenderReplyModal('/mu/thread/post-1');
+
+    const nameInput = container.querySelectorAll<HTMLInputElement>('input[type="text"]')[0];
+    const textarea = container.querySelector<HTMLTextAreaElement>('textarea') as HTMLTextAreaElement;
+    expect(nameInput.value).toBe('');
+
+    await dispatchInput(textarea, 'Account switch regression');
+    await clickButtonByText('post');
+
+    expect(testState.publishReplyMock).toHaveBeenCalledWith(expect.objectContaining({ displayName: undefined }));
   });
 
   it('shows Oekaki draw controls on /i/ replies', async () => {
@@ -651,6 +666,7 @@ describe('ReplyModal', () => {
 
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
       content: '>>42\nselected text',
+      displayName: 'Alice',
       challengeRequest: {
         challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
       },
@@ -677,6 +693,7 @@ describe('ReplyModal', () => {
 
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
       content: '>>42\nselected text',
+      displayName: 'Alice',
       challengeRequest: {
         challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
       },
@@ -697,6 +714,7 @@ describe('ReplyModal', () => {
 
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
       content: '>>42\nselected text',
+      displayName: 'Alice',
       challengeRequest: {
         challengeAnswers: ['bitsocial-flags:5chan:flag:country:auto'],
       },
@@ -718,7 +736,9 @@ describe('ReplyModal', () => {
     await clickButtonByText('post');
 
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'reply body',
+      displayName: 'Alice',
       flairs: [{ type: 'pol', code: 'AC', text: 'flag:pol:AC' }],
     });
   });
@@ -1041,7 +1061,10 @@ describe('ReplyModal', () => {
     expect(linkInput.value).toBe(thumbnailLink);
     expect(textarea.value).toBe(`reply ${youtubeLink} body`);
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: `reply ${youtubeLink} body`,
+      displayName: 'Alice',
+      flairs: undefined,
       link: thumbnailLink,
     });
   });
@@ -1170,7 +1193,10 @@ describe('ReplyModal', () => {
 
     expect(testState.publishReplyMock).toHaveBeenCalledTimes(1);
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: `reply body ${youtubeLink}`,
+      displayName: 'Alice',
+      flairs: undefined,
       link: thumbnailLink,
     });
   });
@@ -1209,7 +1235,10 @@ describe('ReplyModal', () => {
 
     expect(testState.publishReplyMock).toHaveBeenCalledTimes(1);
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'reply body[fortune color=#fd4d32]Excellent Luck[/fortune]',
+      displayName: 'Alice',
+      flairs: undefined,
     });
     randomSpy.mockRestore();
   });
@@ -1270,7 +1299,10 @@ describe('ReplyModal', () => {
 
     expect(testState.publishReplyMock).toHaveBeenCalledTimes(1);
     expect(testState.publishReplyMock).toHaveBeenCalledWith({
+      challengeRequest: undefined,
       content: 'silly reply[fortune color=#fd4d32]Excellent Luck[/fortune]',
+      displayName: 'Alice',
+      flairs: undefined,
     });
     expect(testState.setPublishReplyOptionsMock).toHaveBeenCalledWith({ content: 'silly reply' });
     randomSpy.mockRestore();

--- a/src/components/reply-modal/reply-modal.tsx
+++ b/src/components/reply-modal/reply-modal.tsx
@@ -153,6 +153,7 @@ const ReplyModal = ({ closeModal, locationDraftKey, showReplyModal, parentCid, p
   const moderationPostingRoleLabel = getModerationPostingRoleLabel({ address: accountAddress, role: accountRole });
   const moderationPostingWarning = showBbcodeToolbar && moderationPostingRoleLabel ? `warning: posting as ${moderationPostingRoleLabel}` : undefined;
   const textRef = useRef<HTMLTextAreaElement | null>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
   const setTextRef = useRef((element: HTMLTextAreaElement | null) => {
     textRef.current = element;
     if (!element) return;
@@ -226,6 +227,7 @@ const ReplyModal = ({ closeModal, locationDraftKey, showReplyModal, parentCid, p
       const appliedYouTubeConversion = await applyPendingConversion();
 
       const currentContent = textRef.current?.value || '';
+      const currentDisplayName = nameRef.current?.value.trim() || undefined;
       const currentUrl = urlRef.current?.value.trim() || '';
       const currentOptions = optionsRef.current?.value || '';
       const currentOptionsError = getPostOptionsValidationError(currentOptions, postOptionsDirectoryCode);
@@ -276,6 +278,7 @@ const ReplyModal = ({ closeModal, locationDraftKey, showReplyModal, parentCid, p
       setError(null);
       nonokoRedirectPathRef.current = hasNonokoOption(currentOptions) ? `/${postOptionsDirectoryCode || params.boardIdentifier || communityAddress}` : null;
       await publishReply({
+        displayName: currentDisplayName,
         content: publishContent,
         ...getPublishLinkOptions(currentUrl, appliedYouTubeConversion),
         ...flagPublishOptions,
@@ -619,14 +622,6 @@ const ReplyModal = ({ closeModal, locationDraftKey, showReplyModal, parentCid, p
   const youtubeThumbnailConversionNotice =
     youtubeThumbnailConversionCountdown !== null ? t('youtube_thumbnail_link_conversion_notice', { count: youtubeThumbnailConversionCountdown }) : null;
 
-  const hasInitializedDisplayName = useRef(false);
-  useEffect(() => {
-    if (displayName && !hasInitializedDisplayName.current) {
-      hasInitializedDisplayName.current = true;
-      setPublishReplyOptions({ displayName });
-    }
-  }, [displayName, setPublishReplyOptions]);
-
   const modalContent = (
     <animated.div
       className={styles.container}
@@ -673,7 +668,9 @@ const ReplyModal = ({ closeModal, locationDraftKey, showReplyModal, parentCid, p
       <div className={styles.replyForm}>
         <div className={styles.name}>
           <input
+            key={account?.id ?? account?.name ?? account?.author?.address}
             type='text'
+            ref={nameRef}
             aria-label={t('name')}
             defaultValue={displayName}
             placeholder={displayName ? undefined : capitalize(t('name'))}


### PR DESCRIPTION
## Summary

- reset the uncontrolled Name field when the active account changes
- publish the current Name value atomically so stale optimistic author state is cleared
- cover new threads, inline replies, and reply modals with regression tests

## Verification

- full unit suite
- build, lint, type-check, formatting, and React Doctor
- live account-switch flow in Chromium, Firefox, and WebKit using an isolated temporary community

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how display names are attached at publish time across posts and replies; misbehavior would cause wrong author attribution but scope is limited to form publishing.
> 
> **Overview**
> Fixes a bug where **switching accounts** could still publish under the **previous account’s display name** (or leave a stale name in the Name field when moving to an anonymous account).
> 
> The post form and reply modal now **remount the Name input** when the active account changes (`key` on account id/name/address) so the field resets correctly. On submit, **`displayName` is read from the Name input** via a ref and passed into `publishPost` / `publishReply`, instead of relying on a one-time `useEffect` that seeded publish options from the author profile.
> 
> Regression tests cover account-switch flows for new threads, inline replies, and the reply modal; existing publish assertions were updated to expect explicit `displayName` (and related optional fields) in the publish payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98b59a30b0115a30c140c629824e07a148f1671f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed post and reply publishing so display names update correctly when switching accounts.
  * Prevented a previous account’s display name from appearing when publishing anonymously or with an account that has no name.
  * Ensured the latest display name, challenges, and flairs are included when publishing posts and replies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->